### PR TITLE
Add postStart and preStop lifecycle commands to web application template

### DIFF
--- a/applications/web/Chart.yaml
+++ b/applications/web/Chart.yaml
@@ -9,4 +9,4 @@ keywords:
   - web
 name: web
 type: application
-version: 0.1.1
+version: 0.2.0

--- a/applications/web/Chart.yaml
+++ b/applications/web/Chart.yaml
@@ -9,4 +9,4 @@ keywords:
   - web
 name: web
 type: application
-version: 0.1.0
+version: 0.1.1

--- a/applications/web/form.yaml
+++ b/applications/web/form.yaml
@@ -232,6 +232,28 @@ tabs:
       placeholder: "ex: 30"
       settings:
         default: 30
+  - name: lifecycle_post_start_command
+    contents:
+    - type: heading
+      label: Container post start command
+    - type: subtitle
+      name: post_start_command_description
+      label: (Optional) Set a post start command for this service.
+    - type: string-input
+      label: Post start command
+      placeholder: "ex: /bin/sh -c sleep 5"
+      variable: container.lifecycle.postStart
+  - name: lifecycle_pre_stop_command
+    contents:
+    - type: heading
+      label: Container pre stop command
+    - type: subtitle
+      name: pre_stop_command_description
+      label: (Optional) Set a pre stop command for this service.
+    - type: string-input
+      label: Pre stop command
+      placeholder: "ex: /bin/sh -c sleep 5"
+      variable: container.lifecycle.preStop
   - name: cloud_sql_toggle
     contents:
     - type: heading

--- a/applications/web/form.yaml
+++ b/applications/web/form.yaml
@@ -232,24 +232,16 @@ tabs:
       placeholder: "ex: 30"
       settings:
         default: 30
-  - name: lifecycle_post_start_command
+  - name: container_hooks
     contents:
     - type: heading
-      label: Container post start command
+      label: Container hooks
     - type: subtitle
-      name: post_start_command_description
-      label: (Optional) Set a post start command for this service.
+      label: (Optional) Set post start or pre stop commands for this service.
     - type: string-input
       label: Post start command
       placeholder: "ex: /bin/sh -c sleep 5"
       variable: container.lifecycle.postStart
-  - name: lifecycle_pre_stop_command
-    contents:
-    - type: heading
-      label: Container pre stop command
-    - type: subtitle
-      name: pre_stop_command_description
-      label: (Optional) Set a pre stop command for this service.
     - type: string-input
       label: Pre stop command
       placeholder: "ex: /bin/sh -c sleep 5"

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -37,6 +37,25 @@ spec:
           - {{ $command | quote }}
           {{- end }}
           {{- end }}
+          {{- if or (.Values.container.lifecycle.postStart) (.Values.container.lifecycle.preStop) }}
+          lifecycle:
+            {{- if .Values.container.lifecycle.postStart }}
+            postStart:
+              exec:
+                command: 
+                {{- range $command := trim .Values.container.lifecycle.postStart | split " " }}
+                - {{ $command | quote }}
+                {{- end }}
+            {{- end }}
+            {{- if .Values.container.lifecycle.preStop }}
+            preStop:
+              exec:
+                command: 
+                {{- range $command := trim .Values.container.lifecycle.preStop | split " " }}
+                - {{ $command | quote }}
+                {{- end }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.container.port }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -43,6 +43,9 @@ container:
   command:
   env:
     normal:
+  lifecycle:
+    postStart:
+    preStop:
 
 resources:
   requests:


### PR DESCRIPTION
I've added optional preStop and postStart lifecycle commands to the web application helm chart template.
I also added entries to the corresponding form allowing entering these commands from the "advanced" tab.

LMKWYT

CC @abelanger5 