### PR TITLE
Set memory limits for all containers + sidecars

### DIFF
--- a/applications/job/form.yaml
+++ b/applications/job/form.yaml
@@ -68,6 +68,29 @@ tabs:
       label: Auto-deploy when webhook is called.
       settings:
         default: true
+- name: resources
+  label: Resources
+  sections:
+  - name: main_section
+    contents:
+    - type: heading
+      label: Resources
+    - type: subtitle
+      label: Configure resources assigned to this container.
+    - type: number-input
+      label: RAM
+      variable: resources.requests.memory
+      placeholder: "ex: 256"
+      settings:
+        unit: Mi
+        default: 256
+    - type: number-input
+      label: CPU
+      variable: resources.requests.cpu
+      placeholder: "ex: 100"
+      settings:
+        unit: m
+        default: 100
 - name: advanced
   label: Advanced
   sections:

--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -45,9 +45,21 @@ spec:
                 value: {{ quote $val }}
               {{- end }}
               {{- end }}
+            resources:
+              requests:
+                cpu: {{ .Values.resources.requests.cpu }}
+                memory: {{ .Values.resources.requests.memory }}
+              limits:
+                memory: {{ .Values.resources.requests.memory }}
           - name: sidecar
             image: public.ecr.aws/o1j4x7p4/job-sidecar:latest
             imagePullPolicy: Always
+            resources:
+              requests:
+                cpu: 10m
+                memory: 10Mi
+              limits:
+                memory: 10Mi
             command:
             - "./job_killer.sh"
             {{- if (.Values.sidecar.signalChildProcesses) }}

--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -53,9 +53,21 @@ data:
               value: {{ quote $val }}
             {{- end }}
             {{- end }}
+            resources:
+              requests:
+                cpu: {{ .Values.resources.requests.cpu }}
+                memory: {{ .Values.resources.requests.memory }}
+              limits:
+                memory: {{ .Values.resources.requests.memory }}
           - name: sidecar
             image: public.ecr.aws/o1j4x7p4/job-sidecar:latest
             imagePullPolicy: Always
+            resources:
+              requests:
+                cpu: 10m
+                memory: 10Mi
+              limits:
+                memory: 10Mi
             command:
             - "./job_killer.sh"
             {{- if (.Values.sidecar.signalChildProcesses) }}

--- a/applications/job/templates/hook-delete.yaml
+++ b/applications/job/templates/hook-delete.yaml
@@ -32,4 +32,10 @@ spec:
           value: {{ printf "%s=%s" "meta.helm.sh/release-name" .Release.Name  }}
         - name: JOB_NAMESPACE
           value: {{ .Release.Namespace | quote }}
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 32Mi
 {{ end }}

--- a/applications/job/templates/hook.yaml
+++ b/applications/job/templates/hook.yaml
@@ -32,6 +32,12 @@ spec:
           value: {{ printf "%s=%s" "meta.helm.sh/release-name" .Release.Name  }}
         - name: ALLOW_CONCURRENCY
           value: {{ .Values.allowConcurrency | quote }}
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 32Mi
         volumeMounts:
         - name: manifest-data
           mountPath: /porter/manifest

--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -24,6 +24,11 @@ container:
 schedule: 
   enabled: false 
   value: "*/5 * * * *"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
   
 paused: false
 


### PR DESCRIPTION
Memory limits should be set so that containers are killed if they use too much memory. Sidecar containers and hooks are assigned memory requests/limits as well. 