### PR TITLE
Updated form field example text for container hooks

### DIFF
--- a/applications/web/form.yaml
+++ b/applications/web/form.yaml
@@ -240,11 +240,11 @@ tabs:
       label: (Optional) Set post start or pre stop commands for this service.
     - type: string-input
       label: Post start command
-      placeholder: "ex: /bin/sh -c sleep 5"
+      placeholder: "ex: /bin/sh ./myscript.sh"
       variable: container.lifecycle.postStart
     - type: string-input
       label: Pre stop command
-      placeholder: "ex: /bin/sh -c sleep 5"
+      placeholder: "ex: /bin/sh ./myscript.sh"
       variable: container.lifecycle.preStop
   - name: cloud_sql_toggle
     contents:


### PR DESCRIPTION
This updates the example text shown for "Container hooks" to clarify that specifying a command to be run from file is what only works properly as of now.