### PR TITLE
Fix cluster issuer override

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -29,9 +29,16 @@ metadata:
     {{- end }}
     {{- end }}
     # provider-agnostic default annotations
+    # if value is provided as "null" or null, it is unset 
     {{- if gt (len .Values.ingress.annotations) 0}}
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
-    {{- end }}    
+    {{- range $k, $v := .Values.ingress.annotations }}
+    {{- if $v}}
+    {{- if and (not (eq $v "null")) $v}}
+    {{ $k }}: {{ $v }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
 spec:
   tls:
     - hosts:

--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -18,22 +18,20 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "86400"
-
-    # provider-agnostic default annotations
-    {{ if gt (len .Values.ingress.annotations) 0}}
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
-    {{ end }}
-
-    {{ if gt (len $customPaths) 0 }}
+    {{- if gt (len $customPaths) 0 }}
     nginx.ingress.kubernetes.io/rewrite-target: /
-    {{ end }}
-
-
-    {{ if .Values.ingress.wildcard }}
+    {{- end }}
+    {{- if not (hasKey .Values.ingress.annotations "cert-manager.io/cluster-issuer")}}
+    {{- if .Values.ingress.wildcard }}
     cert-manager.io/cluster-issuer: letsencrypt-prod-wildcard
-    {{ else }}
+    {{- else }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    {{ end }}
+    {{- end }}
+    {{- end }}
+    # provider-agnostic default annotations
+    {{- if gt (len .Values.ingress.annotations) 0}}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- end }}    
 spec:
   tls:
     - hosts:

--- a/applications/web/values-test.yaml
+++ b/applications/web/values-test.yaml
@@ -1,0 +1,3 @@
+ingress:
+  annotations:
+    cert-manager.io/cluster-issuer: whatwhat

--- a/applications/web/values-test.yaml
+++ b/applications/web/values-test.yaml
@@ -1,3 +1,3 @@
 ingress:
   annotations:
-    cert-manager.io/cluster-issuer: whatwhat
+    cert-manager.io/cluster-issuer: 'null'

--- a/applications/web/values-test.yaml
+++ b/applications/web/values-test.yaml
@@ -1,3 +1,0 @@
-ingress:
-  annotations:
-    cert-manager.io/cluster-issuer: 'null'


### PR DESCRIPTION
Allow override for the annotation `cert-manager.io/cluster-issuer`. 

Also fixes write if ingress annotation is set as `null` or `'null'`. 