### PR TITLE
job: show environment variables in separate tab

### DIFF
--- a/applications/job/form.yaml
+++ b/applications/job/form.yaml
@@ -50,15 +50,6 @@ tabs:
       placeholder: "ex: */5 * * * *"
       settings:
         default: "*/5 * * * *"
-  - name: env_vars
-    contents:
-    - type: heading
-      label: Environment Variables
-    - type: subtitle
-      label: Set environment variables for your secrets and environment-specific configuration.
-    - type: env-key-value-array
-      label: 
-      variable: container.env.normal
   - name: webhook
     contents:
     - type: heading
@@ -91,6 +82,18 @@ tabs:
       settings:
         unit: m
         default: 100
+- name: env
+  label: Environment
+  sections:
+    - name: env_vars
+      contents:
+        - type: heading
+          label: Environment Variables
+        - type: subtitle
+          label: Set environment variables for your secrets and environment-specific configuration.
+        - type: env-key-value-array
+          label:
+          variable: container.env.normal
 - name: advanced
   label: Advanced
   sections:


### PR DESCRIPTION
Related: https://github.com/porter-dev/porter/pull/1078

moves "Environment Variables" section from the "Main" tab to a new "Environment" tab, for consistency with `web` and `worker` charts

![image](https://user-images.githubusercontent.com/44864521/130121400-933fbae7-6fec-467b-9055-3be49cf52014.png)