### PR TITLE
[fix] Update job sidecar to kill cloud sql proxy on shutdown

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -68,6 +68,9 @@ spec:
             - {{ .Values.terminationGracePeriodSeconds | quote }}
             {{- $cmdSpl := trim .Values.container.command | split " " }}
             - {{ $cmdSpl._0 | quote }}
+            {{- if .Values.cloudsql.enabled }}
+            - "cloud_sql_proxy"
+            {{- end }}
           {{- if .Values.cloudsql.enabled }}
           - name: cloud-sql-proxy
             image: gcr.io/cloudsql-docker/gce-proxy:1.17

--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -81,6 +81,9 @@ data:
             - {{ .Values.terminationGracePeriodSeconds | quote }}
             {{- $cmdSpl := trim .Values.container.command | split " " }}
             - {{ $cmdSpl._0 | quote }}
+            {{- if .Values.cloudsql.enabled }}
+            - "cloud_sql_proxy"
+            {{- end }}
           {{- if .Values.cloudsql.enabled }}
           - name: cloud-sql-proxy
             image: gcr.io/cloudsql-docker/gce-proxy:1.17


### PR DESCRIPTION
If cloudSQL proxy is enabled for a job, this kills the CloudSQL proxy on shutdown of the sidecar. 