### PR TITLE
Environment variable injection with postgres-toolbox

### DIFF
--- a/addons/postgres-toolbox/templates/deployment.yaml
+++ b/addons/postgres-toolbox/templates/deployment.yaml
@@ -34,8 +34,7 @@ spec:
           env:
           {{- range $key, $val := .Values.container.env.normal }}
             - name: {{ $key }}
-            {{- $splVal := split "_" $val -}}
-            value: {{ quote $val }}
+              value: {{ quote $val }}
           {{- end }}  
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Trying to fix an issue where env vars are not being injected inside the postgres-toolbox Pod.