### PR TITLE
Add security contexts to job sidecar to remove processes

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -54,6 +54,10 @@ spec:
           - name: sidecar
             image: public.ecr.aws/o1j4x7p4/job-sidecar:latest
             imagePullPolicy: Always
+            securityContext:
+              capabilities:
+                add:
+                - SYS_PTRACE
             resources:
               requests:
                 cpu: 10m

--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -67,6 +67,10 @@ data:
           - name: sidecar
             image: public.ecr.aws/o1j4x7p4/job-sidecar:latest
             imagePullPolicy: Always
+            securityContext:
+              capabilities:
+                add:
+                - SYS_PTRACE
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
Seems to be needed for `pgrep` and `kill -TERM` the cloudsql proxy. 