### PR TITLE
Upgrade/kubernetes v1.22

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -5,8 +5,8 @@
 {{- $customPaths := .Values.ingress.custom_paths -}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta" -}}
-apiVersion: networking.k8s.io/v1beta
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
@@ -71,7 +71,9 @@ spec:
             {{ if gt (len $customPaths) 0 }}
             {{- range $customPaths }}
             - path: {{ .path }}
-              pathType: Prefix
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+              pathType: ImplementationSpecific
+              {{- end }}
               backend:
                 {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}                
                 service:

--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -47,7 +47,7 @@ metadata:
     {{- end }}
     {{- end }}
 spec:
-{{- if not .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
   ingressClassName: nginx
 {{- end }}
   {{- if .Values.ingress.tls }}

--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "docker-template.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- $allHosts := concat .Values.ingress.hosts, .Values.ingress.porter_hosts -}}
+{{- $allHosts := concat .Values.ingress.hosts .Values.ingress.porter_hosts -}}
 {{- $customPaths := .Values.ingress.custom_paths -}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1

--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -47,7 +47,7 @@ metadata:
     {{- end }}
     {{- end }}
 spec:
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
   ingressClassName: nginx
 {{- end }}
   {{- if .Values.ingress.tls }}

--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
   labels:
     {{- include "docker-template.labels" . | nindent 4 }}
   annotations:
-  {{- if not .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+  {{- if not (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") }}
     kubernetes.io/ingress.class: "nginx"
   {{- end }}
     nginx.ingress.kubernetes.io/proxy-body-size: 50m

--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- $svcPort := .Values.service.port -}}
 {{- $allHosts := concat .Values.ingress.hosts .Values.ingress.porter_hosts -}}
 {{- $customPaths := .Values.ingress.custom_paths -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
 {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta" -}}
 apiVersion: networking.k8s.io/v1beta
@@ -73,7 +73,7 @@ spec:
             - path: {{ .path }}
               pathType: Prefix
               backend:
-                {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}                
+                {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}                
                 service:
                   name: {{ .serviceName }}
                   port:

--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -86,7 +86,7 @@ spec:
             {{ else }}
             - backend:
               pathType: Prefix
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
                 service:
                   name: {{ $fullName }}
                   port:

--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "docker-template.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- $allHosts := concat .Values.ingress.hosts, .Values.ingress.porter_hosts -}}
 {{- $customPaths := .Values.ingress.custom_paths -}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1
@@ -15,7 +16,9 @@ metadata:
   labels:
     {{- include "docker-template.labels" . | nindent 4 }}
   annotations:
+  {{- if not .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
     kubernetes.io/ingress.class: "nginx"
+  {{- end }}
     nginx.ingress.kubernetes.io/proxy-body-size: 50m
     nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
@@ -44,14 +47,13 @@ metadata:
     {{- end }}
     {{- end }}
 spec:
+{{- if not .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
   ingressClassName: nginx
+{{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     - hosts:
-        {{- range .Values.ingress.hosts }}
-        - {{ . }}
-        {{- end }}
-        {{- range .Values.ingress.porter_hosts }}
+        {{- range $allHosts }}
         - {{ . }}
         {{- end }}
       {{ if .Values.ingress.wildcard }}
@@ -62,40 +64,7 @@ spec:
   {{- end }}
 
   rules:
-    {{- range .Values.ingress.hosts }}
-      - host: {{ . }}
-        http:
-          paths:
-            {{ if gt (len $customPaths) 0 }}
-            {{- range $customPaths }}
-            - path: {{ .path }}
-              pathType: Prefix
-              backend:
-                {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}                
-                service:
-                  name: {{ .serviceName }}
-                  port:
-                    number: {{ .servicePort }}
-                {{- else }}
-                serviceName: {{ .serviceName }} 
-                servicePort: {{ .servicePort }}
-                {{- end }}
-            {{- end }}
-            {{ else }}
-            - backend:
-              pathType: Prefix
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
-                service:
-                  name: {{ $fullName }}
-                  port:
-                    number: {{ $svcPort }}
-              {{- else }}
-                serviceName: {{ $fullName }}
-                servicePort: {{ $svcPort }}
-              {{- end }}
-            {{ end }}
-    {{- end }}
-    {{- range .Values.ingress.porter_hosts }}
+    {{- range $allHosts }}
       - host: {{ . }}
         http:
           paths:

--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -2,8 +2,10 @@
 {{- $fullName := include "docker-template.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $customPaths := .Values.ingress.custom_paths -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta" -}}
+apiVersion: networking.k8s.io/v1beta
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
@@ -42,6 +44,7 @@ metadata:
     {{- end }}
     {{- end }}
 spec:
+  ingressClassName: nginx
   {{- if .Values.ingress.tls }}
   tls:
     - hosts:
@@ -66,14 +69,30 @@ spec:
             {{ if gt (len $customPaths) 0 }}
             {{- range $customPaths }}
             - path: {{ .path }}
+              pathType: Prefix
               backend:
-                serviceName: {{ .serviceName }}
+                {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}                
+                service:
+                  name: {{ .serviceName }}
+                  port:
+                    number: {{ .servicePort }}
+                {{- else }}
+                serviceName: {{ .serviceName }} 
                 servicePort: {{ .servicePort }}
+                {{- end }}
             {{- end }}
             {{ else }}
             - backend:
+              pathType: Prefix
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+                service:
+                  name: {{ $fullName }}
+                  port:
+                    number: {{ $svcPort }}
+              {{- else }}
                 serviceName: {{ $fullName }}
                 servicePort: {{ $svcPort }}
+              {{- end }}
             {{ end }}
     {{- end }}
     {{- range .Values.ingress.porter_hosts }}
@@ -83,14 +102,30 @@ spec:
             {{ if gt (len $customPaths) 0 }}
             {{- range $customPaths }}
             - path: {{ .path }}
+              pathType: Prefix
               backend:
-                serviceName: {{ .serviceName }}
+                {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}                
+                service:
+                  name: {{ .serviceName }}
+                  port:
+                    number: {{ .servicePort }}
+                {{- else }}
+                serviceName: {{ .serviceName }} 
                 servicePort: {{ .servicePort }}
+                {{- end }}
             {{- end }}
             {{ else }}
             - backend:
+              pathType: Prefix
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+                service:
+                  name: {{ $fullName }}
+                  port:
+                    number: {{ $svcPort }}
+              {{- else }}
                 serviceName: {{ $fullName }}
                 servicePort: {{ $svcPort }}
+              {{- end }}
             {{ end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Was setting up dev environment in order to get cracking on implementing some features when I noticed I was having trouble deploying a new app with ingress in my local minikube cluster. 

Some of the beta-apis have been deprecated in kubernetes v1.22 and started following this "guide".

https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/

I think there are some more charts that need updating. mongodb, porteragent, prometheus for example use the "authorization.k8s.io/v1beta1"

While this PR does not adress those, I wanted to submit it as I'm not that experienced in best practices etc when it comes to versioning and deprecations using helm.

When do we allow breaking changes? when do we stop supporting kubernetes EOL versions etc? 🤷 