### PR TITLE
Add support for custom service annotations and additional ports

### DIFF
--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -61,6 +61,11 @@ spec:
             - name: http
               containerPort: {{ .Values.container.port }}
               protocol: TCP
+            {{- range .Values.container.extraPorts }}
+            - name: {{ .name }}
+              containerPort: {{ .containerPort }}
+              protocol: TCP
+            {{- end }}
           {{ if and (not .Values.health.enabled) (.Values.readinessProbe) }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}

--- a/applications/web/templates/service.yaml
+++ b/applications/web/templates/service.yaml
@@ -4,6 +4,12 @@ metadata:
   name: {{ include "docker-template.fullname" . }}
   labels:
     {{- include "docker-template.labels" . | nindent 4 }}
+  {{- if gt (len .Values.ingress.annotations) 0}}
+  annotations:
+    {{- range $k, $v := .Values.service.annotations }}
+    {{ $k }}: {{ $v }}
+    {{- end }}
+  {{- end }}
 spec:
   {{ if .Values.ingress.enabled }}
   type: NodePort
@@ -18,5 +24,14 @@ spec:
       {{- if and .Release.IsUpgrade (not .Values.ingress.enabled) }}
       nodePort: null
       {{- end }}
+  {{- range .Values.service.extraPorts }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: TCP
+      name: {{ .name }}
+      {{- if and $.Release.IsUpgrade (not $.Values.ingress.enabled) }}
+      nodePort: null
+      {{- end }}
+  {{- end }}
   selector:
     {{- include "docker-template.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
This PR adds support for adding custom service `metadata.annotations` and support adding additional ports to listen on under `service.extraPorts` and `container.extraPorts`. For example, to listen on both port 80 and 443, disable ingress, and create an external-facing `nlb-ip` service, the following `values.yaml` now works:

```yaml
service:
  extraPorts:
  - name: https
    targetPort: https
    port: 443
  annotations: 
    service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
container: 
  extraPorts:
  - name: https
    containerPort: 443
ingress:
  enabled: false
```