### PR TITLE
Add configurable timeout limit for job runs

### DIFF
--- a/applications/job/form.yaml
+++ b/applications/job/form.yaml
@@ -110,6 +110,13 @@ tabs:
     - type: heading
       label: Termination Settings
     - type: subtitle
+      label: Specify how much time jobs have to run.
+    - type: number-input
+      label: Job Timeout (seconds)
+      variable: sidecar.timeout
+      settings:
+        default: 3600
+    - type: subtitle
       label: Specify how much time jobs have to gracefully shut down on SIGTERM.
     - type: number-input
       label: Termination Grace Period (seconds)

--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -54,6 +54,11 @@ spec:
           - name: sidecar
             image: public.ecr.aws/o1j4x7p4/job-sidecar:latest
             imagePullPolicy: Always
+            {{- if (.Values.sidecar.timeout) }}
+            env:
+            - name: TIMEOUT
+              value: {{ .Values.sidecar.timeout | quote }}
+            {{- end }}
             resources:
               requests:
                 cpu: 10m

--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -65,7 +65,7 @@ data:
               limits:
                 memory: {{ .Values.resources.requests.memory }}
           - name: sidecar
-            image: public.ecr.aws/o1j4x7p4/job-sidecar:dev
+            image: public.ecr.aws/o1j4x7p4/job-sidecar:latest
             imagePullPolicy: Always
             resources:
               requests:

--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -65,7 +65,7 @@ data:
               limits:
                 memory: {{ .Values.resources.requests.memory }}
           - name: sidecar
-            image: public.ecr.aws/o1j4x7p4/job-sidecar:latest
+            image: public.ecr.aws/o1j4x7p4/job-sidecar:dev
             imagePullPolicy: Always
             resources:
               requests:
@@ -73,6 +73,11 @@ data:
                 memory: 10Mi
               limits:
                 memory: 10Mi
+            {{- if (.Values.sidecar.timeout) }}
+            env:
+            - name: TIMEOUT
+              value: {{ .Values.sidecar.timeout | quote }}
+            {{- end }}
             command:
             - "./job_killer.sh"
             {{- if (.Values.sidecar.signalChildProcesses) }}

--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -40,3 +40,5 @@ cloudsql:
 
 sidecar:
   signalChildProcesses: true
+  # The timeout value in seconds for the job run
+  timeout: 3600


### PR DESCRIPTION
Adds a `sidecar.timeout` field that can terminate a running job process, along with an update to the form allowing users to configure this value. 