### PR TITLE
Healthchecks separation

### DIFF
--- a/applications/web/form.yaml
+++ b/applications/web/form.yaml
@@ -68,7 +68,7 @@ tabs:
           - type: array-input
             variable: ingress.hosts
             label: Domain Name
-      - name: ingress_tls_enabled
+      - name: domain_name
         show_if: ingress.custom_domain
         contents:
           - type: checkbox
@@ -163,7 +163,7 @@ tabs:
             label: Set environment variables for your secrets and environment-specific configuration.
           - type: env-key-value-array
             label:
-            variable: container.env.normal
+            variable: container.env
   - name: advanced
     label: Advanced
     sections:
@@ -213,8 +213,35 @@ tabs:
             variable: health.periodSeconds
             placeholder: "ex: 30"
           - type: checkbox
+            label: Enable Startup Probe
+            variable: health.startupProbe.enabled
+      - name: startup_check_endpoint
+        show_if: health.startupProbe.enabled
+        contents:
+          - type: string-input
+            label: Startup Check Endpoint
+            variable: health.startupProbe.path
+            placeholder: "ex: /startupz"
+            settings:
+              required: true
+              default: /startupz
+          - type: heading
+            label: Custom Startup Check Rules
+          - type: subtitle
+            label: Configure how many times a startup check will be performed before deeming the container as failed.
+          - type: number-input
+            label: Failure Threshold
+            variable: health.startupProbe.failureThreshold
+            placeholder: "ex: 3"
+          - type: subtitle
+            label: Configure the interval at which the startup check is repeated in the case of failure.
+          - type: number-input
+            label: Repeat Interval
+            variable: health.startupProbe.periodSeconds
+            placeholder: "ex: 30"
+          - type: checkbox
             label: Enable Readiness Probe
-            variable: health.readinessProbe.enabled
+            variable: health.readinessProbe.enabled      
       - name: readiness_probe
         show_if: health.readinessProbe.enabled
         contents:

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -100,10 +100,10 @@ spec:
           {{ end }}
           startupProbe:
             httpGet:
-              path: {{ .Values.health.path }}
+              path: {{ .Values.health.startupProbe.path }}
               port: http
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}
           {{ end }}
           resources:
             requests:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -70,6 +70,11 @@ health:
     enabled: false
     path: "/ready"
     periodSeconds: 5
+  startupProbe:
+    enabled: false
+    path: "/startupz"
+    failureThreshold: 3
+    periodSeconds: 5
 
 pvc:
   enabled: false

--- a/applications/worker/form.yaml
+++ b/applications/worker/form.yaml
@@ -110,6 +110,95 @@ tabs:
 - name: advanced
   label: Advanced
   sections:
+  - name: health_check
+    contents:
+    - type: heading
+      label: Custom Health Checks
+    - type: subtitle
+      label: Define custom health check tests to ensure zero down-time deployments.
+    - type: checkbox
+      variable: health.enabled
+      label: Enable Custom Health Checks
+      settings:
+        default: false
+  - name: health_check_command
+    show_if: health.enabled
+    contents:
+    - type: string-input
+      label: Health Check Command
+      variable: health.command
+      placeholder: "ex: ls -l"
+      settings:
+        required: true
+        default: "ls -l"
+    - type: heading
+      label: Custom Health Check Rules
+    - type: subtitle
+      label: Configure how many times a health check will be performed before deeming the container as failed.
+    - type: number-input
+      label: Failure Threshold
+      variable: health.failureThreshold
+      placeholder: "ex: 3"
+    - type: subtitle
+      label: Configure the interval at which health check is repeated in the case of failure.
+    - type: number-input
+      label: Repeat Interval
+      variable: health.periodSeconds
+      placeholder: "ex: 30"
+    - type: checkbox
+      label: Enable Startup Probe
+      variable: health.startupProbe.enabled
+  - name: startup_check_command
+    show_if: health.startupProbe.enabled
+    contents:
+    - type: string-input
+      label: Startup Check Command
+      variable: health.startupProbe.command
+      placeholder: "ex: ls -l"
+      settings:
+        required: true
+        default: "ls -l"
+    - type: heading
+      label: Custom Health Check Rules
+    - type: subtitle
+      label: Configure how many times a startup check will be performed before deeming the container as failed.
+    - type: number-input
+      label: Failure Threshold
+      variable: health.startupProbe.failureThreshold
+      placeholder: "ex: 3"
+    - type: subtitle
+      label: Configure the interval at which health check is repeated in the case of failure.
+    - type: number-input
+      label: Repeat Interval
+      variable: health.startupProbe.periodSeconds
+      placeholder: "ex: 30"
+    - type: checkbox
+      label: Enable Readiness Probe
+      variable: health.readinessProbe.enabled
+  - name: readiness_check_command
+    show_if: health.readinessProbe.enabled
+    contents:
+    - type: string-input
+      label: Startup Check Command
+      variable: health.readinessProbe.command
+      placeholder: "ex: ls -l"
+      settings:
+        required: true
+        default: "ls -l"
+    - type: heading
+      label: Custom Health Check Rules
+    - type: subtitle
+      label: Configure how many times a startup check will be performed before deeming the container as failed.
+    - type: number-input
+      label: Failure Threshold
+      variable: health.readinessProbe.failureThreshold
+      placeholder: "ex: 3"
+    - type: subtitle
+      label: Configure the interval at which health check is repeated in the case of failure.
+    - type: number-input
+      label: Repeat Interval
+      variable: health.readinessProbe.periodSeconds
+      placeholder: "ex: 30"
   - name: persistence_toggle
     contents:
     - type: heading

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -53,6 +53,34 @@ spec:
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           {{ end }}
+          {{ if .Values.health.enabled }}
+          livenessProbe:
+            exec:
+              command:
+              {{- range $command := trim .Values.health.command | split " " }}
+              - {{ $command | quote }}
+              {{- end }}
+            periodSeconds: {{ .Values.health.periodSeconds }}
+            failureThreshold: {{ .Values.health.failureThreshold }}
+          {{- end }}
+          {{ if .Values.health.startupProbe.enabled }}
+          startupProbe:
+            exec:
+              command:
+              {{- range $command := trim .Values.health.startupProbe.command | split " " }}
+              - {{ $command | quote }}
+              {{- end }}
+            periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
+          {{- end }}
+          {{ if .Values.health.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command:
+              {{- range $command := trim .Values.health.readinessProbe.command | split " " }}
+              - {{ $command | quote }}
+              {{- end }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+          {{- end }}
           resources:
             requests:
               cpu: {{ .Values.resources.requests.cpu }}

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -39,6 +39,21 @@ autoscaling:
   targetCPUUtilizationPercentage: 50
   targetMemoryUtilizationPercentage: 50
 
+health:
+  enabled: false
+  command: "ls -l"
+  periodSeconds: 5
+  failureThreshold: 3
+  readinessProbe:
+    enabled: false
+    command: "ls -l"
+    periodSeconds: 5
+  startupProbe:
+    enabled: false
+    command: "ls -l"
+    failureThreshold: 3
+    periodSeconds: 5
+
 pvc:
   enabled: false
   storage: 20Gi


### PR DESCRIPTION
Added support for a separate startup probe check to the `application/web` and `application/worker` charts. Also adding support for making health, readiness and startup checks independent of each other.