### PR TITLE
App name labels

### DIFF
--- a/applications/job/templates/_helpers.tpl
+++ b/applications/job/templates/_helpers.tpl
@@ -54,7 +54,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "docker-template.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "docker-template.name" . }}
+app.kubernetes.io/name: {{ .Release.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/applications/web/templates/_helpers.tpl
+++ b/applications/web/templates/_helpers.tpl
@@ -47,7 +47,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "docker-template.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "docker-template.name" . }}
+app.kubernetes.io/name: {{ .Release.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/applications/worker/templates/_helpers.tpl
+++ b/applications/worker/templates/_helpers.tpl
@@ -47,7 +47,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "docker-template.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "docker-template.name" . }}
+app.kubernetes.io/name: {{ .Release.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 


### PR DESCRIPTION
Modified the web, worker and job charts' templates to include the app name as the default value for the app.kubernetes.io/name label.