### PR TITLE
Add support for retaining failed job hooks

### DIFF
--- a/applications/job/templates/hook.yaml
+++ b/applications/job/templates/hook.yaml
@@ -6,7 +6,11 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
+    {{- if .Values.retainFailedHooks }}
+    "helm.sh/hook-delete-policy": hook-succeeded
+    {{- else }}
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+    {{- end }}
 spec:
   backoffLimit: 0
   template:

--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -42,3 +42,5 @@ sidecar:
   signalChildProcesses: true
   # The timeout value in seconds for the job run
   timeout: 3600
+
+retainFailedHooks: false


### PR DESCRIPTION
Adds the field `retainFailedHooks` which will allow failed hook runs to persist.  