### PR TITLE
Fixing default startup probes

### DIFF
--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -98,12 +98,14 @@ spec:
               port: http
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}          
           {{ end }}
+          {{ if .Values.health.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: {{ .Values.health.startupProbe.path }}
               port: http
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}
+          {{ end }}
           {{ end }}
           resources:
             requests:


### PR DESCRIPTION
Rolling out a fix for a major bug where startup probes were being enabled by default, even in the absence of a startup probe in the web chart's form.