### PR TITLE
Fix duplicate `domain_name` in form.yaml

### DIFF
--- a/applications/web/form.yaml
+++ b/applications/web/form.yaml
@@ -68,7 +68,7 @@ tabs:
           - type: array-input
             variable: ingress.hosts
             label: Domain Name
-      - name: domain_name
+      - name: ingress_tls_enabled
         show_if: ingress.custom_domain
         contents:
           - type: checkbox


### PR DESCRIPTION
Fixes the duplicate `domain_name` field in web `form.yaml`. 