### PR TITLE
Fixing custom Ingress annotations

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -31,9 +31,20 @@ metadata:
     {{- end }}
     {{- end }}
     # provider-agnostic default annotations
-    # if value is provided as "null" or null, it is unset 
+    # if value is provided as "null" or null, it is unset
+    {{- if not (hasKey .Values.ingress.annotations "normal")}} 
     {{- if gt (len .Values.ingress.annotations) 0}}
     {{- range $k, $v := .Values.ingress.annotations }}
+    {{- if $v}}
+    {{- if and (not (eq $v "null")) $v}}
+    {{ $k }}: {{ $v }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- else}}
+    # adding a fix for scenarios where ingress annotations are inside .Values.ingress.annotations.normal
+    {{- if gt (len .Values.ingress.annotations.normal) 0}}
+    {{- range $k, $v := .Values.ingress.annotations.normal }}
     {{- if $v}}
     {{- if and (not (eq $v "null")) $v}}
     {{ $k }}: {{ $v }}


### PR DESCRIPTION
Adding a check for scenarios where custom ingress annotations may be present inside .Values.ingress.annotations.normal.