### PR TITLE
Add tolerations for system nodes to Node Local DNS

### DIFF
--- a/addons/local-dns-cache/templates/localdns.yaml
+++ b/addons/local-dns-cache/templates/localdns.yaml
@@ -34,14 +34,14 @@ metadata:
     kubernetes.io/name: "KubeDNSUpstream"
 spec:
   ports:
-  - name: dns
-    port: 53
-    protocol: UDP
-    targetPort: 53
-  - name: dns-tcp
-    port: 53
-    protocol: TCP
-    targetPort: 53
+    - name: dns
+      port: 53
+      protocol: UDP
+      targetPort: 53
+    - name: dns-tcp
+      port: 53
+      protocol: TCP
+      targetPort: 53
   selector:
     k8s-app: kube-dns
 ---
@@ -128,64 +128,76 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: node-local-dns
       hostNetwork: true
-      dnsPolicy: Default  # Don't use cluster DNS.
+      dnsPolicy: Default # Don't use cluster DNS.
       tolerations:
-      - key: "CriticalAddonsOnly"
-        operator: "Exists"
-      - effect: "NoExecute"
-        operator: "Exists"
-      - effect: "NoSchedule"
-        operator: "Exists"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        - effect: "NoExecute"
+          operator: "Exists"
+        - effect: "NoSchedule"
+          operator: "Exists"
+        - key: "porter.run/workload-kind"
+          operator: "Equal"
+          value: "system"
+          effect: "NoSchedule"
       containers:
-      - name: node-cache
-        image: k8s.gcr.io/dns/k8s-dns-node-cache:1.17.0
-        resources:
-          requests:
-            cpu: 25m
-            memory: 5Mi
-        args: [ "-localip", "169.254.20.10,172.20.0.10", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" ]
-        securityContext:
-          privileged: true
-        ports:
-        - containerPort: 53
-          name: dns
-          protocol: UDP
-        - containerPort: 53
-          name: dns-tcp
-          protocol: TCP
-        - containerPort: 9253
-          name: metrics
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            host: 169.254.20.10
-            path: /health
-            port: 8080
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
-        volumeMounts:
-        - mountPath: /run/xtables.lock
-          name: xtables-lock
-          readOnly: false
-        - name: config-volume
-          mountPath: /etc/coredns
-        - name: kube-dns-config
-          mountPath: /etc/kube-dns
+        - name: node-cache
+          image: k8s.gcr.io/dns/k8s-dns-node-cache:1.17.0
+          resources:
+            requests:
+              cpu: 25m
+              memory: 5Mi
+          args:
+            [
+              "-localip",
+              "169.254.20.10,172.20.0.10",
+              "-conf",
+              "/etc/Corefile",
+              "-upstreamsvc",
+              "kube-dns-upstream",
+            ]
+          securityContext:
+            privileged: true
+          ports:
+            - containerPort: 53
+              name: dns
+              protocol: UDP
+            - containerPort: 53
+              name: dns-tcp
+              protocol: TCP
+            - containerPort: 9253
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              host: 169.254.20.10
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - name: config-volume
+              mountPath: /etc/coredns
+            - name: kube-dns-config
+              mountPath: /etc/kube-dns
       volumes:
-      - name: xtables-lock
-        hostPath:
-          path: /run/xtables.lock
-          type: FileOrCreate
-      - name: kube-dns-config
-        configMap:
-          name: kube-dns
-          optional: true
-      - name: config-volume
-        configMap:
-          name: node-local-dns
-          items:
-            - key: Corefile
-              path: Corefile.base
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+        - name: kube-dns-config
+          configMap:
+            name: kube-dns
+            optional: true
+        - name: config-volume
+          configMap:
+            name: node-local-dns
+            items:
+              - key: Corefile
+                path: Corefile.base
 ---
 # A headless service is a service with a service IP but instead of load-balancing it will return the IPs of our associated Pods.
 # We use this to expose metrics to Prometheus.


### PR DESCRIPTION
Adds tolerations for nodes with taint `porter.run/workload-kind=system` to NLD. 