### PR TITLE
Add a fallback to blue-green deployment mechanism to keep default deployment

### DIFF
--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.statefulset.enabled) (not .Values.bluegreen.enabled) -}}
+{{- if and (not .Values.statefulset.enabled) (or (not .Values.bluegreen.disablePrimaryDeployment) eq (len .Values.bluegreen.imageTags) 0) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.statefulset.enabled) (or (not .Values.bluegreen.disablePrimaryDeployment) eq (len .Values.bluegreen.imageTags) 0) -}}
+{{- if and (not .Values.statefulset.enabled) (or (not .Values.bluegreen.disablePrimaryDeployment) (eq (len .Values.bluegreen.imageTags) 0)) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/applications/web/templates/service.yaml
+++ b/applications/web/templates/service.yaml
@@ -37,6 +37,6 @@ spec:
   {{- end }}
   selector:
     {{- include "docker-template.selectorLabels" . | nindent 4 }}
-    {{- if and .Values.bluegreen.enabled .Values.bluegreen.disablePrimaryDeployment not (eq (len .Values.bluegreen.imageTags) 0)) }}
+    {{- if and .Values.bluegreen.enabled .Values.bluegreen.disablePrimaryDeployment (.Values.bluegreen.imageTags | len | eq 0 | not) }}
     porter.run/blue-green-value: {{ .Values.bluegreen.activeImageTag | quote }}
     {{- end }}

--- a/applications/web/templates/service.yaml
+++ b/applications/web/templates/service.yaml
@@ -37,6 +37,6 @@ spec:
   {{- end }}
   selector:
     {{- include "docker-template.selectorLabels" . | nindent 4 }}
-    {{- if .Values.bluegreen.enabled }}
+    {{- if and .Values.bluegreen.enabled .Values.bluegreen.disablePrimaryDeployment not (eq (len .Values.bluegreen.imageTags) 0)) }}
     porter.run/blue-green-value: {{ .Values.bluegreen.activeImageTag | quote }}
     {{- end }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -92,8 +92,15 @@ nodeSelector: {}
 
 bluegreen:
   enabled: false
+
+  # if this is set to true, the main deployment won't render and the service selector will use the
+  # activeImageTag. For zero-downtime updates, set this to false until the new deployments are created, 
+  # and then set this to true. 
+  disablePrimaryDeployment: false
+
   # if bluegreen is enabled, set the activeImageTag and the list of imageTags
   # activeImageTag: mytag1
+  imageTags: []
   # imageTags:
   # - mytag1
   # - mytag2


### PR DESCRIPTION
If the `bluegreen.imageTags` array is set to empty, keep the default deployment around. Also allows for the boolean `bluegreen.disablePrimaryDeployment` which can be used for zero-downtime migration to the blue-green mechanism. 