### PR TITLE
Hotfix for hanging `backend` block

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -86,8 +86,10 @@ spec:
                 {{- end }}
             {{- end }}
             {{ else }}
-            - backend:
-              pathType: Prefix
+            - {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+              pathType: ImplementationSpecific
+              {{- end }}
+              backend:
               {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
                 service:
                   name: {{ $fullName }}


### PR DESCRIPTION
Hotfix for `mapping values not expected in this context` when attempting a `helm install`. 