### PR TITLE
Hotfix for `v1beta1` capabilities, check for `Ingress` resource

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -5,7 +5,7 @@
 {{- $customPaths := .Values.ingress.custom_paths -}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
We should check for `/Ingress` resource in networking `v1beta1` api group + version. 