### PR TITLE
[Dev] Support for EKS private/internal Ingress

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -116,3 +116,64 @@ spec:
             {{ end }}
     {{- end }}
 {{- end }}
+{{- if .Values.ingress.privateIngress.enabled -}}
+{{- $allPrivateHosts := concat .Values.ingress.privateIngress.hosts  -}}
+---
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+apiVersion: networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-private
+  labels:
+    {{- include "docker-template.labels" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 50m
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: '60'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '60'
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '60'
+  spec:
+    ingressClassName: {{ .Values.ingress.privateIngress.privateIngressClass }}
+    rules:
+    {{- range $allPrivateHosts }}
+      - host: {{ . }}
+        http:
+          paths:
+            {{ if gt (len $customPaths) 0 }}
+            {{- range $customPaths }}
+            - path: {{ .path }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+              pathType: ImplementationSpecific
+              {{- end }}
+              backend:
+                {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}                
+                service:
+                  name: {{ .serviceName }}
+                  port:
+                    number: {{ .servicePort }}
+                {{- else }}
+                serviceName: {{ .serviceName }} 
+                servicePort: {{ .servicePort }}
+                {{- end }}
+            {{- end }}
+            {{ else }}
+            - {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+              pathType: ImplementationSpecific
+              {{- end }}
+              backend:
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+                service:
+                  name: {{ $fullName }}
+                  port:
+                    number: {{ $svcPort }}
+              {{- else }}
+                serviceName: {{ $fullName }}
+                servicePort: {{ $svcPort }}
+              {{- end }}
+            {{ end }}
+    {{- end }}
+{{- end }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -39,6 +39,10 @@ ingress:
   annotations: {}
   wildcard: false
   tls: true
+  privateIngress:
+    enabled: false
+    privateIngressClass:
+    hosts: []
 
 container:
   port: 80


### PR DESCRIPTION
This PR introduces modifications to the web chart, in order to allow for the addition of custom values for enabling a web app to also be exposed over an internal Ingress controller, which is in turn tied to an internal NLB on AWS.