### PR TITLE
Ensure that command args are written in stable ordering

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -34,7 +34,7 @@ spec:
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             {{- if and .Values.container.command (not (or (eq .Values.image.repository "porterdev/hello-porter-job") (eq .Values.image.repository "public.ecr.aws/o1j4x7p4/hello-porter-job"))) }}
             command: 
-            {{- range $command := trim .Values.container.command | split " " }}
+            {{- range $command := trim .Values.container.command | splitList " " }}
             - {{ $command | quote }}
             {{- end }}
             {{- end }}
@@ -93,7 +93,7 @@ spec:
             - "-c"
             {{- end }}
             - {{ .Values.terminationGracePeriodSeconds | quote }}
-            {{- $cmdSpl := trim .Values.container.command | split " " }}
+            {{- $cmdSpl := trim .Values.container.command | splitList " " }}
             - {{ $cmdSpl._0 | quote }}
             {{- if .Values.cloudsql.enabled }}
             - "cloud_sql_proxy"

--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -47,7 +47,7 @@ data:
             imagePullPolicy: "{{ .Values.image.pullPolicy }}"
             {{- if and .Values.container.command (not (or (eq .Values.image.repository "porterdev/hello-porter-job") (eq .Values.image.repository "public.ecr.aws/o1j4x7p4/hello-porter-job"))) }}
             command: 
-            {{- range $command := trim .Values.container.command | split " " }}
+            {{- range $command := trim .Values.container.command | splitList " " }}
             - {{ $command | quote }}
             {{- end }}
             {{- end }}
@@ -106,7 +106,7 @@ data:
             - "-c"
             {{- end }}
             - {{ .Values.terminationGracePeriodSeconds | quote }}
-            {{- $cmdSpl := trim .Values.container.command | split " " }}
+            {{- $cmdSpl := trim .Values.container.command | splitList " " }}
             - {{ $cmdSpl._0 | quote }}
             {{- if .Values.cloudsql.enabled }}
             - "cloud_sql_proxy"

--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -36,7 +36,7 @@ spec:
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           {{- if and $.Values.container.command (not (or (eq $.Values.image.repository "porterdev/hello-porter") (eq $.Values.image.repository "public.ecr.aws/o1j4x7p4/hello-porter"))) }}
           command: 
-          {{- range $command := trim $.Values.container.command | split " " }}
+          {{- range $command := trim $.Values.container.command | splitList " " }}
           - {{ $command | quote }}
           {{- end }}
           {{- end }}
@@ -46,7 +46,7 @@ spec:
             postStart:
               exec:
                 command: 
-                {{- range $command := trim $.Values.container.lifecycle.postStart | split " " }}
+                {{- range $command := trim $.Values.container.lifecycle.postStart | splitList " " }}
                 - {{ $command | quote }}
                 {{- end }}
             {{- end }}
@@ -54,7 +54,7 @@ spec:
             preStop:
               exec:
                 command: 
-                {{- range $command := trim $.Values.container.lifecycle.preStop | split " " }}
+                {{- range $command := trim $.Values.container.lifecycle.preStop | splitList " " }}
                 - {{ $command | quote }}
                 {{- end }}
             {{- end }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if and .Values.container.command (not (or (eq .Values.image.repository "porterdev/hello-porter") (eq .Values.image.repository "public.ecr.aws/o1j4x7p4/hello-porter"))) }}
           command: 
-          {{- range $command := trim .Values.container.command | split " " }}
+          {{- range $command := trim .Values.container.command | splitList " " }}
           - {{ $command | quote }}
           {{- end }}
           {{- end }}
@@ -44,7 +44,7 @@ spec:
             postStart:
               exec:
                 command: 
-                {{- range $command := trim .Values.container.lifecycle.postStart | split " " }}
+                {{- range $command := trim .Values.container.lifecycle.postStart | splitList " " }}
                 - {{ $command | quote }}
                 {{- end }}
             {{- end }}
@@ -52,7 +52,7 @@ spec:
             preStop:
               exec:
                 command: 
-                {{- range $command := trim .Values.container.lifecycle.preStop | split " " }}
+                {{- range $command := trim .Values.container.lifecycle.preStop | splitList " " }}
                 - {{ $command | quote }}
                 {{- end }}
             {{- end }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if and .Values.container.command (not (or (eq .Values.image.repository "porterdev/hello-porter") (eq .Values.image.repository "public.ecr.aws/o1j4x7p4/hello-porter"))) }}
           command: 
-          {{- range $command := trim .Values.container.command | split " " }}
+          {{- range $command := trim .Values.container.command | splitList " " }}
           - {{ $command | quote }}
           {{- end }}
           {{- end }}
@@ -57,7 +57,7 @@ spec:
           livenessProbe:
             exec:
               command:
-              {{- range $command := trim .Values.health.command | split " " }}
+              {{- range $command := trim .Values.health.command | splitList " " }}
               - {{ $command | quote }}
               {{- end }}
             periodSeconds: {{ .Values.health.periodSeconds }}
@@ -67,7 +67,7 @@ spec:
           startupProbe:
             exec:
               command:
-              {{- range $command := trim .Values.health.startupProbe.command | split " " }}
+              {{- range $command := trim .Values.health.startupProbe.command | splitList " " }}
               - {{ $command | quote }}
               {{- end }}
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
@@ -76,7 +76,7 @@ spec:
           readinessProbe:
             exec:
               command:
-              {{- range $command := trim .Values.health.readinessProbe.command | split " " }}
+              {{- range $command := trim .Values.health.readinessProbe.command | splitList " " }}
               - {{ $command | quote }}
               {{- end }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}


### PR DESCRIPTION
We're currently using the `split` method which outputs a dict of values (randomly traversed). This only seems to be breaking commands with over 10 values. This PR switches to using `splitList` instead, which outputs an array. 