### PR TITLE
Add option to remove rewrite target for ingress

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
-    {{- if gt (len $customPaths) 0 }}
+    {{- if and (gt (len $customPaths) 0) .Values.ingress.rewriteCustomPathsEnabled }}
     nginx.ingress.kubernetes.io/rewrite-target: /
     {{- end }}
     {{- if .Values.ingress.tls }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -36,6 +36,7 @@ ingress:
   provider: aws
   custom_domain: false
   custom_paths: []
+  rewriteCustomPathsEnabled: true
   annotations: {}
   wildcard: false
   tls: true


### PR DESCRIPTION
Adds the option `ingress.rewriteCustomPathsEnabled` to give the option of removing rewrite targets. 