### PR TITLE
Add quotes for hostnames to support wildcards

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -68,7 +68,7 @@ spec:
   tls:
     - hosts:
         {{- range $allHosts }}
-        - {{ . }}
+        - {{ . | quote }}
         {{- end }}
       {{ if .Values.ingress.wildcard }}
       secretName: wildcard-cert-tls
@@ -79,7 +79,7 @@ spec:
 
   rules:
     {{- range $allHosts }}
-      - host: {{ . }}
+      - host: {{ . | quote }}
         http:
           paths:
             {{ if gt (len $customPaths) 0 }}


### PR DESCRIPTION
Hostnames currently don't support wildcards as hosts values aren't quoted, which throws a YAML error.