### PR TITLE
[Dev] Support for intra-cluster access over NodePorts for n8n

### DIFF
--- a/addons/n8n/form.yaml
+++ b/addons/n8n/form.yaml
@@ -14,6 +14,12 @@ tabs:
       label: Expose to external traffic
       settings:
         default: true
+  - name: nodeport_field
+    show_if: ingress.enabled
+    contents:
+      - type: number-input
+        label: Optionally assign a NodePort for n8n, in order to ensure n8n is only accessible from within your cluster VPC network. Use a port between 30000-32767
+        variable: service.nodePort
   - name: domain_toggle
     show_if: ingress.enabled
     contents:

--- a/addons/n8n/templates/service.yaml
+++ b/addons/n8n/templates/service.yaml
@@ -15,5 +15,8 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{ if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{ end }}
   selector:
     {{- include "docker-template.selectorLabels" . | nindent 4 }}

--- a/addons/n8n/values.yaml
+++ b/addons/n8n/values.yaml
@@ -41,6 +41,7 @@ container:
 
 service:
   port: 80
+  nodePort:
 
 ingress:
   enabled: true


### PR DESCRIPTION
Added support for specifying a NodePort to ensure N8n is only accessible from within the cluster's VPC network.