### PR TITLE
Azure Ingress support

### DIFF
--- a/addons/https-issuer/templates/clusterissuer.yaml
+++ b/addons/https-issuer/templates/clusterissuer.yaml
@@ -15,4 +15,4 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: nginx
+          class: {{ .Values.ingressClass }}

--- a/addons/https-issuer/values.yaml
+++ b/addons/https-issuer/values.yaml
@@ -1,6 +1,7 @@
 email: "contact@getporter.dev"
 gce:
   enabled: false
+ingressClass: nginx
 wildcard:
   enabled: false
   do_access_token: "" 

--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -62,7 +62,11 @@ metadata:
     {{- end }}
 spec:
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if eq .Values.ingress.provider "azure" }}
+  ingressClassName: azure-application-gateway
+{{- else }}
   ingressClassName: nginx
+{{- end }}
 {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -19,6 +19,9 @@ metadata:
   {{- if not (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") }}
     kubernetes.io/ingress.class: "nginx"
   {{- end }}
+  {{- if eq .Values.ingress.provider "azure" }}
+    kubernetes.io/ingress.class: addon-http-application-routing
+  {{- end }}
     nginx.ingress.kubernetes.io/proxy-body-size: 50m
     nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
@@ -62,9 +65,7 @@ metadata:
     {{- end }}
 spec:
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-{{- if eq .Values.ingress.provider "azure" }}
-  ingressClassName: azure-application-gateway
-{{- else }}
+{{- if ne .Values.ingress.provider "azure" }}
   ingressClassName: nginx
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR introduces changes to the `https-issuer` chart and the Porter web chart to support different `IngressClasses` for Azure Kubernetes Service's `ingress-nginx` implementation.