### PR TITLE
Healthchecks for B/G deployments

### DIFF
--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -68,17 +68,28 @@ spec:
               containerPort: {{ .containerPort }}
               protocol: TCP
             {{- end }}
-          {{ if ($.Values.readinessProbe.enabled) }}
-          readinessProbe:
-            {{- toYaml $.Values.readinessProbe | nindent 12 }}
-          {{ end }}
-          {{ if ($.Values.startupProbe.enabled) }}
-          startupProbe:
-            {{- toYaml $.Values.startupProbe | nindent 12 }}
-          {{ end }}
-          {{ if ($.Values.livenessProbe.enabled) }}
+          {{ if .Values.health.livenessProbe.enabled }}
           livenessProbe:
-            {{- toYaml $.Values.livenessProbe | nindent 12 }}
+            httpGet:
+              path: {{ .Values.health.livenessProbe.path }}
+              port: http
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
+          {{ end }}
+          {{ if .Values.health.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.health.readinessProbe.path }}
+              port: http
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+          {{ end }}
+          {{ if .Values.health.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.health.startupProbe.path }}
+              port: http
+            periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}
           {{ end }}
           resources:
             requests:


### PR DESCRIPTION
Fixed an issue with health checks for the B/G deployment template - brought it at par with rolling deployments.