### PR TITLE
Basic Auth for healthchecks

### DIFF
--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -76,7 +76,7 @@ spec:
               {{ if .Values.health.livenessProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ printf "%s:%s" .Values.livenessProbe.auth.username .Values.livenessProbe.auth.password | b64enc | quote }}
+                  value: Basic {{ printf "%s:%s" .Values.health.livenessProbe.auth.username .Values.health.livenessProbe.auth.password | b64enc | quote }}
               {{ end }}
             periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
@@ -89,7 +89,7 @@ spec:
               {{ if .Values.health.readinessProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ printf "%s:%s" .Values.readinessProbe.auth.username .Values.readinessProbe.auth.password | b64enc | quote }}
+                  value: Basic {{ printf "%s:%s" .Values.health.readinessProbe.auth.username .Values.health.readinessProbe.auth.password | b64enc | quote }}
               {{ end }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
           {{ end }}
@@ -101,7 +101,7 @@ spec:
             {{ if .Values.health.startupProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ printf "%s:%s" .Values.startupProbe.auth.username .Values.startupProbe.auth.password | b64enc | quote }}
+                  value: Basic {{ printf "%s:%s" .Values.health.startupProbe.auth.username .Values.health.startupProbe.auth.password | b64enc | quote }}
               {{ end }}
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}

--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -68,28 +68,43 @@ spec:
               containerPort: {{ .containerPort }}
               protocol: TCP
             {{- end }}
-          {{ if $.Values.health.livenessProbe.enabled }}
+          {{ if .Values.health.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ $.Values.health.livenessProbe.path }}
+              path: {{ .Values.health.livenessProbe.path }}
               port: http
-            periodSeconds: {{ $.Values.health.livenessProbe.periodSeconds }}
-            failureThreshold: {{ $.Values.health.livenessProbe.failureThreshold }}
+            {{ if .Values.health.livenessProbe.auth.enabled }}
+            httpHeaders:
+              - name: Authorization
+                value: Basic {{ .Values.livenessProbe.auth.basicAuthHeader }}
+            {{ end }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
           {{ end }}
-          {{ if $.Values.health.readinessProbe.enabled }}
+          {{ if .Values.health.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ $.Values.health.readinessProbe.path }}
+              path: {{ .Values.health.readinessProbe.path }}
               port: http
-            periodSeconds: {{ $.Values.health.readinessProbe.periodSeconds }}
+            {{ if .Values.health.readinessProbe.auth.enabled }}
+            httpHeaders:
+              - name: Authorization
+                value: Basic {{ .Values.readinessProbe.auth.basicAuthHeader }}
+            {{ end }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
           {{ end }}
-          {{ if $.Values.health.startupProbe.enabled }}
+          {{ if .Values.health.startupProbe.enabled }}
           startupProbe:
             httpGet:
-              path: {{ $.Values.health.startupProbe.path }}
+              path: {{ .Values.health.startupProbe.path }}
               port: http
-            periodSeconds: {{ $.Values.health.startupProbe.periodSeconds }}
-            failureThreshold: {{ $.Values.health.startupProbe.failureThreshold }}
+            {{ if .Values.health.startupProbe.auth.enabled }}
+            httpHeaders:
+              - name: Authorization
+                value: Basic {{ .Values.startupProbe.auth.basicAuthHeader }}
+            {{ end }}
+            periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}
           {{ end }}
           resources:
             requests:

--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -76,7 +76,7 @@ spec:
               {{ if .Values.health.livenessProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ .Values.livenessProbe.auth.basicAuthHeader }}
+                  value: Basic {{ printf "%s:%s" .Values.livenessProbe.auth.username .Values.livenessProbe.auth.password | b64enc | quote }}
               {{ end }}
             periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
@@ -89,7 +89,7 @@ spec:
               {{ if .Values.health.readinessProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ .Values.health.readinessProbe.auth.basicAuthHeader }}
+                  value: Basic {{ printf "%s:%s" .Values.readinessProbe.auth.username .Values.readinessProbe.auth.password | b64enc | quote }}
               {{ end }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
           {{ end }}
@@ -101,7 +101,7 @@ spec:
             {{ if .Values.health.startupProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ .Values.startupProbe.auth.basicAuthHeader }}
+                  value: Basic {{ printf "%s:%s" .Values.startupProbe.auth.username .Values.startupProbe.auth.password | b64enc | quote }}
               {{ end }}
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}

--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -76,7 +76,7 @@ spec:
               {{ if .Values.health.livenessProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ printf "%s:%s" .Values.health.livenessProbe.auth.username .Values.health.livenessProbe.auth.password | b64enc | quote }}
+                  value: Basic {{ printf "%s:%s" .Values.health.livenessProbe.auth.username .Values.health.livenessProbe.auth.password | b64enc }}
               {{ end }}
             periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
@@ -89,7 +89,7 @@ spec:
               {{ if .Values.health.readinessProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ printf "%s:%s" .Values.health.readinessProbe.auth.username .Values.health.readinessProbe.auth.password | b64enc | quote }}
+                  value: Basic {{ printf "%s:%s" .Values.health.readinessProbe.auth.username .Values.health.readinessProbe.auth.password | b64enc }}
               {{ end }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
           {{ end }}
@@ -101,7 +101,7 @@ spec:
             {{ if .Values.health.startupProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ printf "%s:%s" .Values.health.startupProbe.auth.username .Values.health.startupProbe.auth.password | b64enc | quote }}
+                  value: Basic {{ printf "%s:%s" .Values.health.startupProbe.auth.username .Values.health.startupProbe.auth.password | b64enc }}
               {{ end }}
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}

--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -73,11 +73,11 @@ spec:
             httpGet:
               path: {{ .Values.health.livenessProbe.path }}
               port: http
-            {{ if .Values.health.livenessProbe.auth.enabled }}
-            httpHeaders:
-              - name: Authorization
-                value: Basic {{ .Values.livenessProbe.auth.basicAuthHeader }}
-            {{ end }}
+              {{ if .Values.health.livenessProbe.auth.enabled }}
+              httpHeaders:
+                - name: Authorization
+                  value: Basic {{ .Values.livenessProbe.auth.basicAuthHeader }}
+              {{ end }}
             periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
           {{ end }}
@@ -86,11 +86,11 @@ spec:
             httpGet:
               path: {{ .Values.health.readinessProbe.path }}
               port: http
-            {{ if .Values.health.readinessProbe.auth.enabled }}
-            httpHeaders:
-              - name: Authorization
-                value: Basic {{ .Values.readinessProbe.auth.basicAuthHeader }}
-            {{ end }}
+              {{ if .Values.health.readinessProbe.auth.enabled }}
+              httpHeaders:
+                - name: Authorization
+                  value: Basic {{ .Values.health.readinessProbe.auth.basicAuthHeader }}
+              {{ end }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
           {{ end }}
           {{ if .Values.health.startupProbe.enabled }}
@@ -99,10 +99,10 @@ spec:
               path: {{ .Values.health.startupProbe.path }}
               port: http
             {{ if .Values.health.startupProbe.auth.enabled }}
-            httpHeaders:
-              - name: Authorization
-                value: Basic {{ .Values.startupProbe.auth.basicAuthHeader }}
-            {{ end }}
+              httpHeaders:
+                - name: Authorization
+                  value: Basic {{ .Values.startupProbe.auth.basicAuthHeader }}
+              {{ end }}
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}
           {{ end }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -77,6 +77,11 @@ spec:
             httpGet:
               path: {{ .Values.health.livenessProbe.path }}
               port: http
+            {{ if .Values.health.livenessProbe.auth.enabled }}
+            httpHeaders:
+              - name: Authorization
+                value: Basic {{ .Values.livenessProbe.auth.basicAuthHeader }}
+            {{ end }}
             periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
           {{ end }}
@@ -85,6 +90,11 @@ spec:
             httpGet:
               path: {{ .Values.health.readinessProbe.path }}
               port: http
+            {{ if .Values.health.readinessProbe.auth.enabled }}
+            httpHeaders:
+              - name: Authorization
+                value: Basic {{ .Values.readinessProbe.auth.basicAuthHeader }}
+            {{ end }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
           {{ end }}
           {{ if .Values.health.startupProbe.enabled }}
@@ -92,6 +102,11 @@ spec:
             httpGet:
               path: {{ .Values.health.startupProbe.path }}
               port: http
+            {{ if .Values.health.startupProbe.auth.enabled }}
+            httpHeaders:
+              - name: Authorization
+                value: Basic {{ .Values.startupProbe.auth.basicAuthHeader }}
+            {{ end }}
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}
           {{ end }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
               {{ if .Values.health.livenessProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ printf "%s:%s" .Values.health.livenessProbe.auth.username .Values.health.livenessProbe.auth.password | b64enc | quote }}
+                  value: Basic {{ printf "%s:%s" .Values.health.livenessProbe.auth.username .Values.health.livenessProbe.auth.password | b64enc }}
               {{ end }}
             periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
@@ -93,7 +93,7 @@ spec:
               {{ if .Values.health.readinessProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ printf "%s:%s" .Values.health.readinessProbe.auth.username .Values.health.readinessProbe.auth.password | b64enc | quote }}
+                  value: Basic {{ printf "%s:%s" .Values.health.readinessProbe.auth.username .Values.health.readinessProbe.auth.password | b64enc }}
               {{ end }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
           {{ end }}
@@ -105,7 +105,7 @@ spec:
             {{ if .Values.health.startupProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ printf "%s:%s" .Values.health.startupProbe.auth.username .Values.health.startupProbe.auth.password | b64enc | quote }}
+                  value: Basic {{ printf "%s:%s" .Values.health.startupProbe.auth.username .Values.health.startupProbe.auth.password | b64enc }}
               {{ end }}
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -77,11 +77,11 @@ spec:
             httpGet:
               path: {{ .Values.health.livenessProbe.path }}
               port: http
-            {{ if .Values.health.livenessProbe.auth.enabled }}
-            httpHeaders:
-              - name: Authorization
-                value: Basic {{ .Values.livenessProbe.auth.basicAuthHeader }}
-            {{ end }}
+              {{ if .Values.health.livenessProbe.auth.enabled }}
+              httpHeaders:
+                - name: Authorization
+                  value: Basic {{ .Values.livenessProbe.auth.basicAuthHeader }}
+              {{ end }}
             periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
           {{ end }}
@@ -90,11 +90,11 @@ spec:
             httpGet:
               path: {{ .Values.health.readinessProbe.path }}
               port: http
-            {{ if .Values.health.readinessProbe.auth.enabled }}
-            httpHeaders:
-              - name: Authorization
-                value: Basic {{ .Values.health.readinessProbe.auth.basicAuthHeader }}
-            {{ end }}
+              {{ if .Values.health.readinessProbe.auth.enabled }}
+              httpHeaders:
+                - name: Authorization
+                  value: Basic {{ .Values.health.readinessProbe.auth.basicAuthHeader }}
+              {{ end }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
           {{ end }}
           {{ if .Values.health.startupProbe.enabled }}
@@ -103,10 +103,10 @@ spec:
               path: {{ .Values.health.startupProbe.path }}
               port: http
             {{ if .Values.health.startupProbe.auth.enabled }}
-            httpHeaders:
-              - name: Authorization
-                value: Basic {{ .Values.startupProbe.auth.basicAuthHeader }}
-            {{ end }}
+              httpHeaders:
+                - name: Authorization
+                  value: Basic {{ .Values.startupProbe.auth.basicAuthHeader }}
+              {{ end }}
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}
           {{ end }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
             {{ if .Values.health.readinessProbe.auth.enabled }}
             httpHeaders:
               - name: Authorization
-                value: Basic {{ .Values.readinessProbe.auth.basicAuthHeader }}
+                value: Basic {{ .Values.health.readinessProbe.auth.basicAuthHeader }}
             {{ end }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
           {{ end }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
               {{ if .Values.health.livenessProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ printf "%s:%s" .Values.livenessProbe.auth.username .Values.livenessProbe.auth.password | b64enc | quote }}
+                  value: Basic {{ printf "%s:%s" .Values.health.livenessProbe.auth.username .Values.health.livenessProbe.auth.password | b64enc | quote }}
               {{ end }}
             periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
@@ -93,7 +93,7 @@ spec:
               {{ if .Values.health.readinessProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ printf "%s:%s" .Values.readinessProbe.auth.username .Values.readinessProbe.auth.password | b64enc | quote }}
+                  value: Basic {{ printf "%s:%s" .Values.health.readinessProbe.auth.username .Values.health.readinessProbe.auth.password | b64enc | quote }}
               {{ end }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
           {{ end }}
@@ -105,7 +105,7 @@ spec:
             {{ if .Values.health.startupProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ printf "%s:%s" .Values.startupProbe.auth.username .Values.startupProbe.auth.password | b64enc | quote }}
+                  value: Basic {{ printf "%s:%s" .Values.health.startupProbe.auth.username .Values.health.startupProbe.auth.password | b64enc | quote }}
               {{ end }}
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
               {{ if .Values.health.livenessProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ .Values.livenessProbe.auth.basicAuthHeader }}
+                  value: Basic {{ printf "%s:%s" .Values.livenessProbe.auth.username .Values.livenessProbe.auth.password | b64enc | quote }}
               {{ end }}
             periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
@@ -93,7 +93,7 @@ spec:
               {{ if .Values.health.readinessProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ .Values.health.readinessProbe.auth.basicAuthHeader }}
+                  value: Basic {{ printf "%s:%s" .Values.readinessProbe.auth.username .Values.readinessProbe.auth.password | b64enc | quote }}
               {{ end }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
           {{ end }}
@@ -105,7 +105,7 @@ spec:
             {{ if .Values.health.startupProbe.auth.enabled }}
               httpHeaders:
                 - name: Authorization
-                  value: Basic {{ .Values.startupProbe.auth.basicAuthHeader }}
+                  value: Basic {{ printf "%s:%s" .Values.startupProbe.auth.username .Values.startupProbe.auth.password | b64enc | quote }}
               {{ end }}
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -106,7 +106,8 @@ health:
     failureThreshold: 3
     auth:
       enabled: false
-      basicAuthHeader: ""
+      username: ""
+      password: ""
 
   readinessProbe:
     enabled: false
@@ -114,7 +115,8 @@ health:
     periodSeconds: 5
     auth:
       enabled: false
-      basicAuthHeader: ""
+      username: ""
+      password: ""
 
   startupProbe:
     enabled: false
@@ -123,7 +125,8 @@ health:
     periodSeconds: 5
     auth:
       enabled: false
-      basicAuthHeader: ""
+      username: ""
+      password: ""
 
 pvc:
   enabled: false

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -106,7 +106,7 @@ health:
     failureThreshold: 3
     auth:
       enabled: false
-      basicAuthHeader:
+      basicAuthHeader: ""
 
   readinessProbe:
     enabled: false
@@ -114,7 +114,7 @@ health:
     periodSeconds: 5
     auth:
       enabled: false
-      basicAuthHeader:
+      basicAuthHeader: ""
 
   startupProbe:
     enabled: false
@@ -123,7 +123,7 @@ health:
     periodSeconds: 5
     auth:
       enabled: false
-      basicAuthHeader:
+      basicAuthHeader: ""
 
 pvc:
   enabled: false

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -104,17 +104,26 @@ health:
     path: "/livez"
     periodSeconds: 5
     failureThreshold: 3
+    auth:
+      enabled: false
+      basicAuthHeader:
 
   readinessProbe:
     enabled: false
     path: "/readyz"
     periodSeconds: 5
+    auth:
+      enabled: false
+      basicAuthHeader:
 
   startupProbe:
     enabled: false
     path: "/startupz"
     failureThreshold: 3
     periodSeconds: 5
+    auth:
+      enabled: false
+      basicAuthHeader:
 
 pvc:
   enabled: false


### PR DESCRIPTION
This PR adds support for HTTP Basic Auth for healthcheck endpoints.

Note - to generate the header: `echo -n "<username>:<password>" | base64`