### PR TITLE
Add option to not specify TLS secret

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -75,11 +75,13 @@ spec:
         {{- range $allHosts }}
         - {{ . | quote }}
         {{- end }}
+      {{- if not .Values.ingress.useDefaultIngressTLSSecret }}
       {{ if .Values.ingress.wildcard }}
       secretName: wildcard-cert-tls
       {{ else }}
       secretName: {{ include "docker-template.fullname" . }}  
       {{ end }}
+      {{- end }}
   {{- end }}
 
   rules:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -40,6 +40,7 @@ ingress:
   annotations: {}
   wildcard: false
   tls: true
+  useDefaultIngressTLSSecret: false
 
 
 privateIngress:


### PR DESCRIPTION
Adds the option `useDefaultIngressTLSSecret` - when set to true, no `secretName` is written so that ingress-nginx can use a default TLS certificate.