### PR TITLE
Support for HTTP healthcheck schemes

### DIFF
--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -72,6 +72,7 @@ spec:
           livenessProbe:
             httpGet:
               path: {{ .Values.health.livenessProbe.path }}
+              scheme: {{ .Values.health.livenessProbe.scheme }}
               port: http
               {{ if .Values.health.livenessProbe.auth.enabled }}
               httpHeaders:
@@ -85,6 +86,7 @@ spec:
           readinessProbe:
             httpGet:
               path: {{ .Values.health.readinessProbe.path }}
+              scheme: {{ .Values.health.readinessProbe.scheme }}
               port: http
               {{ if .Values.health.readinessProbe.auth.enabled }}
               httpHeaders:
@@ -97,6 +99,7 @@ spec:
           startupProbe:
             httpGet:
               path: {{ .Values.health.startupProbe.path }}
+              scheme: {{ .Values.health.startupProbe.scheme }}
               port: http
             {{ if .Values.health.startupProbe.auth.enabled }}
               httpHeaders:

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -76,6 +76,7 @@ spec:
           livenessProbe:
             httpGet:
               path: {{ .Values.health.livenessProbe.path }}
+              scheme: {{ .Values.health.livenessProbe.scheme }}
               port: http
               {{ if .Values.health.livenessProbe.auth.enabled }}
               httpHeaders:
@@ -89,6 +90,7 @@ spec:
           readinessProbe:
             httpGet:
               path: {{ .Values.health.readinessProbe.path }}
+              scheme: {{ .Values.health.readinessProbe.scheme }}
               port: http
               {{ if .Values.health.readinessProbe.auth.enabled }}
               httpHeaders:
@@ -101,6 +103,7 @@ spec:
           startupProbe:
             httpGet:
               path: {{ .Values.health.startupProbe.path }}
+              scheme: {{ .Values.health.startupProbe.scheme }}
               port: http
             {{ if .Values.health.startupProbe.auth.enabled }}
               httpHeaders:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -103,6 +103,7 @@ health:
   livenessProbe:
     enabled: false
     path: "/livez"
+    scheme: "http"
     periodSeconds: 5
     failureThreshold: 3
     auth:
@@ -113,6 +114,7 @@ health:
   readinessProbe:
     enabled: false
     path: "/readyz"
+    scheme: "http"
     periodSeconds: 5
     auth:
       enabled: false
@@ -122,6 +124,7 @@ health:
   startupProbe:
     enabled: false
     path: "/startupz"
+    scheme: "http"
     failureThreshold: 3
     periodSeconds: 5
     auth:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -124,7 +124,7 @@ health:
   startupProbe:
     enabled: false
     path: "/startupz"
-    scheme: "http"
+    scheme: "HTTP"
     failureThreshold: 3
     periodSeconds: 5
     auth:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -103,7 +103,7 @@ health:
   livenessProbe:
     enabled: false
     path: "/livez"
-    scheme: "http"
+    scheme: "HTTP"
     periodSeconds: 5
     failureThreshold: 3
     auth:
@@ -114,7 +114,7 @@ health:
   readinessProbe:
     enabled: false
     path: "/readyz"
-    scheme: "http"
+    scheme: "HTTP"
     periodSeconds: 5
     auth:
       enabled: false


### PR DESCRIPTION
Added support for HTTP healthcheck schemes to the web chart. The default is http, while it can be customised to support https.