### PR TITLE
rudimk/http-healthchecks-scheme -> dev

### DIFF
--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -124,7 +124,7 @@ health:
   startupProbe:
     enabled: false
     path: "/startupz"
-    scheme: "http"
+    scheme: "HTTP"
     failureThreshold: 3
     periodSeconds: 5
     auth:


### PR DESCRIPTION
Missed out on the fact that K8s uses upper-case constants - HTTP/HTTPS - for healthcheck schemes.