### PR TITLE
rudimk/http-healthchecks-test -> dev

### DIFF
--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -103,7 +103,7 @@ health:
   livenessProbe:
     enabled: false
     path: "/livez"
-    scheme: "http"
+    scheme: "HTTP"
     periodSeconds: 5
     failureThreshold: 3
     auth:
@@ -114,7 +114,7 @@ health:
   readinessProbe:
     enabled: false
     path: "/readyz"
-    scheme: "http"
+    scheme: "HTTP"
     periodSeconds: 5
     auth:
       enabled: false


### PR DESCRIPTION
Fixed a bug where 'HTTP' was not defined correctly for the liveness and readiness probes.