### PR TITLE
Revert "[Production]Added support for specifying probe timeouts."

### DIFF
--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -81,7 +81,6 @@ spec:
               {{ end }}
             periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.health.livenessProbe.timeoutSeconds }}
           {{ end }}
           {{ if .Values.health.readinessProbe.enabled }}
           readinessProbe:
@@ -95,7 +94,6 @@ spec:
                   value: Basic {{ printf "%s:%s" .Values.health.readinessProbe.auth.username .Values.health.readinessProbe.auth.password | b64enc }}
               {{ end }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.health.readinessProbe.timeoutSeconds }}
           {{ end }}
           {{ if .Values.health.startupProbe.enabled }}
           startupProbe:
@@ -110,7 +108,6 @@ spec:
               {{ end }}
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.health.startupProbe.timeoutSeconds }}
           {{ end }}
           resources:
             requests:

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -85,7 +85,6 @@ spec:
               {{ end }}
             periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.health.livenessProbe.timeoutSeconds }}
           {{ end }}
           {{ if .Values.health.readinessProbe.enabled }}
           readinessProbe:
@@ -99,7 +98,6 @@ spec:
                   value: Basic {{ printf "%s:%s" .Values.health.readinessProbe.auth.username .Values.health.readinessProbe.auth.password | b64enc }}
               {{ end }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.health.readinessProbe.timeoutSeconds }}
           {{ end }}
           {{ if .Values.health.startupProbe.enabled }}
           startupProbe:
@@ -114,7 +112,6 @@ spec:
               {{ end }}
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.health.startupProbe.timeoutSeconds }}
           {{ end }}
           resources:
             requests:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -106,7 +106,6 @@ health:
     scheme: "HTTP"
     periodSeconds: 5
     failureThreshold: 3
-    timeoutSeconds: 1
     auth:
       enabled: false
       username: ""
@@ -117,7 +116,6 @@ health:
     path: "/readyz"
     scheme: "HTTP"
     periodSeconds: 5
-    timeoutSeconds: 1
     auth:
       enabled: false
       username: ""
@@ -129,7 +127,6 @@ health:
     scheme: "HTTP"
     failureThreshold: 3
     periodSeconds: 5
-    timeoutSeconds: 1
     auth:
       enabled: false
       username: ""


### PR DESCRIPTION
Reverts porter-dev/porter-charts#398