### PR TITLE
New Relic addon

### DIFF
--- a/addons/nri-bundle/.helmignore
+++ b/addons/nri-bundle/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/addons/nri-bundle/Chart.lock
+++ b/addons/nri-bundle/Chart.lock
@@ -1,0 +1,33 @@
+dependencies:
+- name: newrelic-infrastructure
+  repository: https://newrelic.github.io/nri-kubernetes
+  version: 3.6.2
+- name: nri-prometheus
+  repository: https://newrelic.github.io/nri-prometheus
+  version: 2.1.6
+- name: nri-metadata-injection
+  repository: https://newrelic.github.io/k8s-metadata-injection
+  version: 3.0.4
+- name: newrelic-k8s-metrics-adapter
+  repository: https://newrelic.github.io/newrelic-k8s-metrics-adapter
+  version: 0.7.5
+- name: kube-state-metrics
+  repository: https://kubernetes.github.io/kube-state-metrics
+  version: 2.13.2
+- name: nri-kube-events
+  repository: https://newrelic.github.io/nri-kube-events
+  version: 2.2.4
+- name: newrelic-logging
+  repository: https://newrelic.github.io/helm-charts
+  version: 1.10.11
+- name: newrelic-pixie
+  repository: https://newrelic.github.io/helm-charts
+  version: 2.0.0
+- name: pixie-operator-chart
+  repository: https://pixie-operator-charts.storage.googleapis.com
+  version: 0.0.26
+- name: newrelic-infra-operator
+  repository: https://newrelic.github.io/newrelic-infra-operator
+  version: 1.0.3
+digest: sha256:ab631693482ea1566ff73cbaadaf4f35878378c2cb46e2fad589b72da3004963
+generated: "2022-06-21T11:59:31.535607335Z"

--- a/addons/nri-bundle/Chart.yaml
+++ b/addons/nri-bundle/Chart.yaml
@@ -1,0 +1,93 @@
+apiVersion: v2
+name: nri-bundle
+description: Groups together the individual charts for the New Relic Kubernetes solution for a more comfortable deployment.
+home: https://github.com/newrelic/helm-charts
+icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
+sources:
+  - https://github.com/newrelic/nri-bundle/
+  - https://github.com/newrelic/nri-bundle/tree/master/charts/nri-bundle
+  - https://github.com/newrelic/nri-kubernetes/tree/master/charts/newrelic-infrastructure
+  - https://github.com/newrelic/nri-prometheus/tree/master/charts/nri-prometheus
+  - https://github.com/newrelic/k8s-metadata-injection/tree/master/charts/nri-metadata-injection
+  - https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/master/charts/newrelic-k8s-metrics-adapter
+  - https://github.com/newrelic/nri-kube-events/tree/master/charts/nri-kube-events
+  - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging
+  - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
+  - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
+
+version: 4.6.1
+
+dependencies:
+  - name: newrelic-infrastructure
+    repository: https://newrelic.github.io/nri-kubernetes
+    condition: infrastructure.enabled,newrelic-infrastructure.enabled
+    version: 3.6.2
+
+  - name: nri-prometheus
+    repository: https://newrelic.github.io/nri-prometheus
+    condition: prometheus.enabled,nri-prometheus.enabled
+    version: 2.1.6
+
+  - name: nri-metadata-injection
+    repository: https://newrelic.github.io/k8s-metadata-injection
+    condition: webhook.enabled,nri-metadata-injection.enabled
+    version: 3.0.4
+
+  - name: newrelic-k8s-metrics-adapter
+    repository: https://newrelic.github.io/newrelic-k8s-metrics-adapter
+    condition: metrics-adapter.enabled,newrelic-k8s-metrics-adapter.enabled
+    version: 0.7.5
+
+  - name: kube-state-metrics
+    repository: https://kubernetes.github.io/kube-state-metrics
+    condition: ksm.enabled,kube-state-metrics.enabled
+    version: 2.13.2
+
+  - name: nri-kube-events
+    repository: https://newrelic.github.io/nri-kube-events
+    condition: kubeEvents.enabled,nri-kube-events.enabled
+    version: 2.2.4
+
+  - name: newrelic-logging
+    repository: https://newrelic.github.io/helm-charts
+    condition: logging.enabled,newrelic-logging.enabled
+    version: 1.10.11
+
+  - name: newrelic-pixie
+    repository: https://newrelic.github.io/helm-charts
+    condition: newrelic-pixie.enabled
+    version: 2.0.0
+
+  - name: pixie-operator-chart
+    alias: pixie-chart
+    repository: https://pixie-operator-charts.storage.googleapis.com
+    condition: pixie-chart.enabled
+    version: 0.0.26
+
+  - name: newrelic-infra-operator
+    repository: https://newrelic.github.io/newrelic-infra-operator
+    condition: newrelic-infra-operator.enabled
+    version: 1.0.3
+
+maintainers:
+  - name: alvarocabanas
+    url: https://github.com/alvarocabanas
+  - name: carlossscastro
+    url: https://github.com/carlossscastro
+  - name: sigilioso
+    url: https://github.com/sigilioso
+  - name: gsanchezgavier
+    url: https://github.com/gsanchezgavier
+  - name: kang-makes
+    url: https://github.com/kang-makes
+  - name: marcsanmi
+    url: https://github.com/marcsanmi
+  - name: paologallinaharbur
+    url: https://github.com/paologallinaharbur
+  - name: roobre
+    url: https://github.com/roobre
+
+keywords:
+  - infrastructure
+  - newrelic
+  - monitoring

--- a/addons/nri-bundle/README.md
+++ b/addons/nri-bundle/README.md
@@ -1,0 +1,160 @@
+# nri-bundle
+
+![Version: 4.6.0](https://img.shields.io/badge/Version-4.6.0-informational?style=flat-square)
+
+Groups together the individual charts for the New Relic Kubernetes solution for a more comfortable deployment.
+
+**Homepage:** <https://github.com/newrelic/helm-charts>
+
+## Bundled charts
+
+This chart does not deploy anything by itself but has many charts as dependencies. This allows you to easily install and upgrade the New Relic
+Kubernetes Integration using only one chart.
+
+In case you need more information about each component this chart installs, or you are an advanced user that want to install each component separately,
+here is a list of components that this chart installs and where you can find more information about them:
+
+| Component                    | Installed by default? | Description |
+|------------------------------|-----------------------|-------------|
+| [newrelic-infrastructure](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure) | Yes | Sends metrics about nodes, cluster objects (e.g. Deployments, Pods), and the control plane to New Relic. |
+| [nri-metadata-injection](https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection) | Yes | Enriches New Relic-instrumented applications (APM) with Kubernetes information. |
+| [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) | | Required for `newrelic-infrastructure` to gather cluster-level metrics. |
+| [nri-kube-events](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events) | | Reports Kubernetes events to New Relic. |
+| [newrelic-infra-operator](https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator) | | (Beta) Used with Fargate or serverless environments to inject `newrelic-infrastructure` as a sidecar instead of the usual DaemonSet. |
+| [newrelic-k8s-metrics-adapter](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) |  | (Beta) Provides a source of data for Horizontal Pod Autoscalers (HPA) based on a NRQL query from New Relic. |
+| [newrelic-logging](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) |  | Sends logs for Kubernetes components and workloads running on the cluster to New Relic. |
+| [nri-prometheus](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus) |  | Sends metrics from applications exposing Prometheus metrics to New Relic. |
+| [newrelic-pixie](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie) |  | Connects to the Pixie API and enables the New Relic plugin in Pixie. The plugin allows you to export data from Pixie to New Relic for long-term data retention. |
+| [Pixie](https://docs.pixielabs.ai/installing-pixie/install-schemes/helm/#3.-deploy) |  | Is an open source observability tool for Kubernetes applications that uses eBPF to automatically capture telemetry data without the need for manual instrumentation. |
+
+## Configure components
+
+It is possible to configure settings for the individual charts this chart groups by specifying values for them under a key using the name of the chart,
+as specified in [helm documentation](https://helm.sh/docs/chart_template_guide/subcharts_and_globals).
+
+For example, by adding the following to the `values.yml` file:
+
+```yaml
+# Configuration settings for the newrelic-infrastructure chart
+newrelic-infrastructure:
+  # Any key defined in the values.yml file for the newrelic-infrastructure chart can be configured here:
+  # https://github.com/newrelic/nri-kubernetes/blob/main/charts/newrelic-infrastructure/values.yaml
+
+  verboseLog: false
+
+  resources:
+    limits:
+      memory: 512M
+```
+
+It is possible to override any entry of the [`newrelic-infrastructure`](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
+chart, as defined in their [`values.yml` file](https://github.com/newrelic/nri-kubernetes/blob/main/charts/newrelic-infrastructure/values.yaml).
+
+The same approach can be followed to update any of the subcharts.
+
+After making these changes to the `values.yml` file, or a custom values file, make sure to apply them using:
+
+```
+$ helm upgrade --reuse-values -f values.yaml [RELEASE] newrelic/nri-bundle
+```
+
+Where `[RELEASE]` is the name of the helm release, e.g. `newrelic-bundle`.
+
+## Monitor on host integrations
+
+If you wish to monitor services running on Kubernetes you can provide integrations
+configuration under `integrations_config` that it will passed down to the `newrelic-infrastructure` chart.
+
+You just need to create a new entry where the "name" is the filename of the configuration file and the data is the content of
+the integration configuration. The name must end in ".yaml" as this will be the
+filename generated and the Infrastructure agent only looks for YAML files.
+
+The data part is the actual integration configuration as described in the spec here:
+https://docs.newrelic.com/docs/integrations/integrations-sdk/file-specifications/integration-configuration-file-specifications-agent-v180
+
+In the following example you can see how to monitor a Redis integration with autodiscovery
+
+```yaml
+newrelic-infrastructure:
+  integrations:
+    nri-redis-sampleapp:
+      discovery:
+        command:
+          exec: /var/db/newrelic-infra/nri-discovery-kubernetes --tls --port 10250
+          match:
+            label.app: sampleapp
+      integrations:
+        - name: nri-redis
+          env:
+            # using the discovered IP as the hostname address
+            HOSTNAME: ${discovery.ip}
+            PORT: 6379
+          labels:
+            env: test
+```
+
+## Values managed globally
+
+Some of the subchart implement the [New Relic's common Helm library](https://github.com/newrelic/helm-charts/tree/master/library/common-library) which
+means that it honors a wide range of defaults and globals common to most New Relic Helm charts.
+
+Options that can be defined globally include `affinity`, `nodeSelector`, `tolerations`, `proxy` and others. The full list can be found at
+[user's guide of the common library](https://github.com/newrelic/helm-charts/blob/master/library/common-library/README.md).
+
+At the time of writing this document, all the charts from `nri-bundle` except `newrelic-logging` and `synthetics-minion` implements this library and
+honors global options as described below.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| global | object | See [`values.yaml`](values.yaml) | change the behaviour globally to all the supported helm charts. See [user's guide of the common library](https://github.com/newrelic/helm-charts/blob/master/library/common-library/README.md) for further information. |
+| global.affinity | object | `{}` | Sets pod/node affinities |
+| global.cluster | string | `""` | The cluster name for the Kubernetes cluster. |
+| global.containerSecurityContext | object | `{}` | Sets security context (at container level) |
+| global.customAttributes | object | `{}` | Adds extra attributes to the cluster and all the metrics emitted to the backend |
+| global.customSecretLicenseKey | string | `""` | Key in the Secret object where the license key is stored |
+| global.customSecretName | string | `""` | Name of the Secret object where the license key is stored |
+| global.dnsConfig | object | `{}` | Sets pod's dnsConfig |
+| global.fargate | bool | false | Must be set to `true` when deploying in an EKS Fargate environment |
+| global.hostNetwork | bool | false | Sets pod's hostNetwork |
+| global.images.pullSecrets | list | `[]` | Set secrets to be able to fetch images |
+| global.images.registry | string | `""` | Changes the registry where to get the images. Useful when there is an internal image cache/proxy |
+| global.insightsKey | string | `""` | The license key for your New Relic Account. This will be preferred configuration option if both `insightsKey` and `customSecret` are specified. |
+| global.labels | object | `{}` | Additional labels for chart objects |
+| global.licenseKey | string | `""` | The license key for your New Relic Account. This will be preferred configuration option if both `licenseKey` and `customSecret` are specified. |
+| global.lowDataMode | bool | false | Reduces number of metrics sent in order to reduce costs |
+| global.nodeSelector | object | `{}` | Sets pod's node selector |
+| global.nrStaging | bool | false | Send the metrics to the staging backend. Requires a valid staging license key |
+| global.podLabels | object | `{}` | Additional labels for chart pods |
+| global.podSecurityContext | object | `{}` | Sets security context (at pod level) |
+| global.priorityClassName | string | `""` | Sets pod's priorityClassName |
+| global.privileged | bool | false | In each integration it has different behavior. See [Further information](#values-managed-globally-3) but all aims to send less metrics to the backend to try to save costs | |
+| global.proxy | string | `""` | Configures the integration to send all HTTP/HTTPS request through the proxy in that URL. The URL should have a standard format like `https://user:password@hostname:port` |
+| global.serviceAccount.annotations | object | `{}` | Add these annotations to the service account we create |
+| global.serviceAccount.create | string | `nil` | Configures if the service account should be created or not |
+| global.serviceAccount.name | string | `nil` | Change the name of the service account. This is honored if you disable on this chart the creation of the service account so you can use your own |
+| global.tolerations | list | `[]` | Sets pod's tolerations to node taints |
+| global.verboseLog | bool | false | Sets the debug logs to this integration or all integrations if it is set globally |
+| kube-state-metrics.collectors | object | See [`values.yaml`](values.yaml) of the kube-state-metric chart | Collectors configuration of kube-state-metric |
+| kube-state-metrics.enabled | bool | `false` | Install the [`kube-state-metrics` chart](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) from the stable helm charts repository. This is mandatory if `infrastructure.enabled` is set to `true` and the user does not provide its own instance of KSM version >=1.8 and <=2.0 |
+| newrelic-infra-operator.enabled | bool | `false` | Install the [`newrelic-infra-operator` chart](https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator) (Beta) |
+| newrelic-infrastructure.enabled | bool | `true` | Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure) |
+| newrelic-k8s-metrics-adapter.enabled | bool | `false` | Install the [`newrelic-k8s-metrics-adapter.` chart](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) (Beta) |
+| newrelic-logging.enabled | bool | `false` | Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) |
+| newrelic-pixie.enabled | bool | `false` | Install the [`newrelic-pixie`](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie) |
+| nri-kube-events.enabled | bool | `false` | Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events) |
+| nri-metadata-injection.enabled | bool | `true` | Install the [`nri-metadata-injection` chart](https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection) |
+| nri-prometheus.enabled | bool | `false` | Install the [`nri-prometheus` chart](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus) |
+| pixie-chart.enabled | bool | `false` | Install the [`pixie-chart` chart](https://docs.pixielabs.ai/installing-pixie/install-schemes/helm/#3.-deploy) |
+
+## Maintainers
+
+* [alvarocabanas](https://github.com/alvarocabanas)
+* [carlossscastro](https://github.com/carlossscastro)
+* [sigilioso](https://github.com/sigilioso)
+* [gsanchezgavier](https://github.com/gsanchezgavier)
+* [kang-makes](https://github.com/kang-makes)
+* [marcsanmi](https://github.com/marcsanmi)
+* [paologallinaharbur](https://github.com/paologallinaharbur)
+* [roobre](https://github.com/roobre)

--- a/addons/nri-bundle/README.md.gotmpl
+++ b/addons/nri-bundle/README.md.gotmpl
@@ -1,0 +1,122 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## Bundled charts
+
+This chart does not deploy anything by itself but has many charts as dependencies. This allows you to easily install and upgrade the New Relic
+Kubernetes Integration using only one chart.
+
+In case you need more information about each component this chart installs, or you are an advanced user that want to install each component separately,
+here is a list of components that this chart installs and where you can find more information about them:
+
+| Component                    | Installed by default? | Description |
+|------------------------------|-----------------------|-------------|
+| [newrelic-infrastructure](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure) | Yes | Sends metrics about nodes, cluster objects (e.g. Deployments, Pods), and the control plane to New Relic. |
+| [nri-metadata-injection](https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection) | Yes | Enriches New Relic-instrumented applications (APM) with Kubernetes information. |
+| [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) | | Required for `newrelic-infrastructure` to gather cluster-level metrics. |
+| [nri-kube-events](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events) | | Reports Kubernetes events to New Relic. |
+| [newrelic-infra-operator](https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator) | | (Beta) Used with Fargate or serverless environments to inject `newrelic-infrastructure` as a sidecar instead of the usual DaemonSet. |
+| [newrelic-k8s-metrics-adapter](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) |  | (Beta) Provides a source of data for Horizontal Pod Autoscalers (HPA) based on a NRQL query from New Relic. |
+| [newrelic-logging](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) |  | Sends logs for Kubernetes components and workloads running on the cluster to New Relic. |
+| [nri-prometheus](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus) |  | Sends metrics from applications exposing Prometheus metrics to New Relic. |
+| [newrelic-pixie](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie) |  | Connects to the Pixie API and enables the New Relic plugin in Pixie. The plugin allows you to export data from Pixie to New Relic for long-term data retention. |
+| [Pixie](https://docs.pixielabs.ai/installing-pixie/install-schemes/helm/#3.-deploy) |  | Is an open source observability tool for Kubernetes applications that uses eBPF to automatically capture telemetry data without the need for manual instrumentation. |
+
+## Configure components
+
+It is possible to configure settings for the individual charts this chart groups by specifying values for them under a key using the name of the chart,
+as specified in [helm documentation](https://helm.sh/docs/chart_template_guide/subcharts_and_globals).
+
+For example, by adding the following to the `values.yml` file:
+
+```yaml
+# Configuration settings for the newrelic-infrastructure chart
+newrelic-infrastructure:
+  # Any key defined in the values.yml file for the newrelic-infrastructure chart can be configured here:
+  # https://github.com/newrelic/nri-kubernetes/blob/main/charts/newrelic-infrastructure/values.yaml
+
+  verboseLog: false
+
+  resources:
+    limits:
+      memory: 512M
+```
+
+It is possible to override any entry of the [`newrelic-infrastructure`](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
+chart, as defined in their [`values.yml` file](https://github.com/newrelic/nri-kubernetes/blob/main/charts/newrelic-infrastructure/values.yaml).
+
+The same approach can be followed to update any of the subcharts.
+
+After making these changes to the `values.yml` file, or a custom values file, make sure to apply them using:
+
+```
+$ helm upgrade --reuse-values -f values.yaml [RELEASE] newrelic/nri-bundle
+```
+
+Where `[RELEASE]` is the name of the helm release, e.g. `newrelic-bundle`.
+
+
+## Monitor on host integrations
+
+If you wish to monitor services running on Kubernetes you can provide integrations
+configuration under `integrations_config` that it will passed down to the `newrelic-infrastructure` chart.
+
+You just need to create a new entry where the "name" is the filename of the configuration file and the data is the content of
+the integration configuration. The name must end in ".yaml" as this will be the
+filename generated and the Infrastructure agent only looks for YAML files.
+
+The data part is the actual integration configuration as described in the spec here:
+https://docs.newrelic.com/docs/integrations/integrations-sdk/file-specifications/integration-configuration-file-specifications-agent-v180
+
+In the following example you can see how to monitor a Redis integration with autodiscovery
+
+```yaml
+newrelic-infrastructure:
+  integrations:
+    nri-redis-sampleapp:
+      discovery:
+        command:
+          exec: /var/db/newrelic-infra/nri-discovery-kubernetes --tls --port 10250
+          match:
+            label.app: sampleapp
+      integrations:
+        - name: nri-redis
+          env:
+            # using the discovered IP as the hostname address
+            HOSTNAME: ${discovery.ip}
+            PORT: 6379
+          labels:
+            env: test
+```
+
+## Values managed globally
+
+Some of the subchart implement the [New Relic's common Helm library](https://github.com/newrelic/helm-charts/tree/master/library/common-library) which
+means that it honors a wide range of defaults and globals common to most New Relic Helm charts.
+
+Options that can be defined globally include `affinity`, `nodeSelector`, `tolerations`, `proxy` and others. The full list can be found at
+[user's guide of the common library](https://github.com/newrelic/helm-charts/blob/master/library/common-library/README.md).
+
+At the time of writing this document, all the charts from `nri-bundle` except `newrelic-logging` and `synthetics-minion` implements this library and
+honors global options as described below.
+
+{{ template "chart.valuesSection" . }}
+
+{{ if .Maintainers }}
+## Maintainers
+{{ range .Maintainers }}
+{{- if .Name }}
+{{- if .Url }}
+* [{{ .Name }}]({{ .Url }})
+{{- else }}
+* {{ .Name }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/addons/nri-bundle/ci/test-values.yaml
+++ b/addons/nri-bundle/ci/test-values.yaml
@@ -1,0 +1,21 @@
+global:
+  licenseKey: 1234567890abcdef1234567890abcdef12345678
+  cluster: test-cluster
+
+infrastructure:
+  enabled: true
+
+prometheus:
+  enabled: true
+
+webhook:
+  enabled: true
+
+ksm:
+  enabled: true
+
+kubeEvents:
+  enabled: true
+
+logging:
+  enabled: true

--- a/addons/nri-bundle/form.yaml
+++ b/addons/nri-bundle/form.yaml
@@ -1,0 +1,17 @@
+name: New Relic agent
+tabs:
+- name: main
+  label: Info
+  sections:
+  - name: section_one
+    contents: 
+    - type: heading
+      label: Deploy New Relic
+    - type: subtitle
+      label: This installs the consolidated New Relic Kubernetes agent, for which you need to supply a cluster name - ideally one that's unique to your New Relic dashboard, as well as your license key.
+    - type: string-input
+      label: New Relic License Key
+      variable: global.licenseKey
+    - type: string-input
+      label: Cluster Name
+      variable: global.cluster

--- a/addons/nri-bundle/values.yaml
+++ b/addons/nri-bundle/values.yaml
@@ -1,0 +1,164 @@
+newrelic-infrastructure:
+  # newrelic-infrastructure.enabled -- Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
+  enabled: true
+
+nri-prometheus:
+  # nri-prometheus.enabled -- Install the [`nri-prometheus` chart](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus)
+  enabled: false
+
+nri-metadata-injection:
+  # nri-metadata-injection.enabled -- Install the [`nri-metadata-injection` chart](https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection)
+  enabled: true
+
+kube-state-metrics:
+  # kube-state-metrics.enabled -- Install the [`kube-state-metrics` chart](https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics) from the stable helm charts repository.
+  # This is mandatory if `infrastructure.enabled` is set to `true` and the user does not provide its own instance of KSM version >=1.8 and <=2.0
+  enabled: false
+  # kube-state-metrics.collectors -- Collectors configuration of kube-state-metric
+  # @default -- See [`values.yaml`](values.yaml) of the kube-state-metric chart
+  collectors:
+    certificatesigningrequests: false
+    ingresses: false
+
+nri-kube-events:
+  # nri-kube-events.enabled -- Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events)
+  enabled: false
+
+newrelic-logging:
+  # newrelic-logging.enabled -- Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging)
+  enabled: false
+
+newrelic-pixie:
+  # newrelic-pixie.enabled -- Install the [`newrelic-pixie`](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie)
+  enabled: false
+
+pixie-chart:
+  # pixie-chart.enabled -- Install the [`pixie-chart` chart](https://docs.pixielabs.ai/installing-pixie/install-schemes/helm/#3.-deploy)
+  enabled: false
+
+newrelic-infra-operator:
+  # newrelic-infra-operator.enabled -- Install the [`newrelic-infra-operator` chart](https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator) (Beta)
+  enabled: false
+
+newrelic-k8s-metrics-adapter:
+  # newrelic-k8s-metrics-adapter.enabled -- Install the [`newrelic-k8s-metrics-adapter.` chart](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) (Beta)
+  enabled: false
+
+
+# -- change the behaviour globally to all the supported helm charts.
+# See [user's guide of the common library](https://github.com/newrelic/helm-charts/blob/master/library/common-library/README.md) for further information.
+# @default -- See [`values.yaml`](values.yaml)
+global:
+  # -- The cluster name for the Kubernetes cluster.
+  cluster: ""
+
+  # -- The license key for your New Relic Account. This will be preferred configuration option if both `licenseKey` and `customSecret` are specified.
+  licenseKey: ""
+  # -- The license key for your New Relic Account. This will be preferred configuration option if both `insightsKey` and `customSecret` are specified.
+  insightsKey: ""
+  # -- Name of the Secret object where the license key is stored
+  customSecretName: ""
+  # -- Key in the Secret object where the license key is stored
+  customSecretLicenseKey: ""
+
+  # -- Additional labels for chart objects
+  labels: {}
+  # -- Additional labels for chart pods
+  podLabels: {}
+
+  images:
+    # -- Changes the registry where to get the images. Useful when there is an internal image cache/proxy
+    registry: ""
+    # -- Set secrets to be able to fetch images
+    pullSecrets: []
+
+  serviceAccount:
+    # -- Add these annotations to the service account we create
+    annotations: {}
+    # -- Configures if the service account should be created or not
+    create:
+    # -- Change the name of the service account. This is honored if you disable on this chart the creation of the service account so you can use your own
+    name:
+
+  # -- (bool) Sets pod's hostNetwork
+  # @default -- false
+  hostNetwork:
+  # -- Sets pod's dnsConfig
+  dnsConfig: {}
+
+  # -- Sets pod's priorityClassName
+  priorityClassName: ""
+  # -- Sets security context (at pod level)
+  podSecurityContext: {}
+  # -- Sets security context (at container level)
+  containerSecurityContext: {}
+
+  # -- Sets pod/node affinities
+  affinity: {}
+  # -- Sets pod's node selector
+  nodeSelector: {}
+  # -- Sets pod's tolerations to node taints
+  tolerations: []
+
+  # -- Adds extra attributes to the cluster and all the metrics emitted to the backend
+  customAttributes: {}
+
+  # -- (bool) Reduces number of metrics sent in order to reduce costs
+  # @default -- false
+  lowDataMode:
+
+  # -- (bool) In each integration it has different behavior. See [Further information](#values-managed-globally-3) but all aims to send less metrics to the backend to try to save costs |
+  # @default -- false
+  privileged:
+
+  # -- (bool) Must be set to `true` when deploying in an EKS Fargate environment
+  # @default -- false
+  fargate:
+
+  # -- Configures the integration to send all HTTP/HTTPS request through the proxy in that URL. The URL should have a standard format like `https://user:password@hostname:port`
+  proxy: ""
+
+  # -- (bool) Send the metrics to the staging backend. Requires a valid staging license key
+  # @default -- false
+  nrStaging:
+  fedramp:
+    # fedramp.enabled -- (bool) Enables FedRAMP
+    # @default -- false
+    enabled:
+
+  # -- (bool) Sets the debug logs to this integration or all integrations if it is set globally
+  # @default -- false
+  verboseLog:
+
+
+# To add values to the subcharts. Follow Helm's guide: https://helm.sh/docs/chart_template_guide/subcharts_and_globals
+
+# If you wish to monitor services running on Kubernetes you can provide integrations
+# configuration under `integrations_config` that it will passed down to the `newrelic-infrastructure` chart.
+#
+# You just need to create a new entry where the "name" is the filename of the configuration file and the data is the content of
+# the integration configuration. The name must end in ".yaml" as this will be the
+# filename generated and the Infrastructure agent only looks for YAML files.
+#
+# The data part is the actual integration configuration as described in the spec here:
+# https://docs.newrelic.com/docs/integrations/integrations-sdk/file-specifications/integration-configuration-file-specifications-agent-v180
+#
+# In the following example you can see how to monitor a Redis integration with autodiscovery
+#
+#
+# newrelic-infrastructure:
+#   integrations:
+#     nri-redis-sampleapp:
+#       discovery:
+#         command:
+#           exec: /var/db/newrelic-infra/nri-discovery-kubernetes --tls --port 10250
+#           match:
+#             label.app: sampleapp
+#       integrations:
+#         - name: nri-redis
+#           env:
+#             # using the discovered IP as the hostname address
+#             HOSTNAME: ${discovery.ip}
+#             PORT: 6379
+#           labels:
+#             env: test


### PR DESCRIPTION
This PR adds the https://github.com/newrelic/helm-charts/tree/master/charts/nri-bundle chart to our addons, along with support for a form asking users to punch in their New Relic license key and a cluster name.