### PR TITLE
Added Target's Pod Reaper as an addon for managing Pod lifetimes.

### DIFF
--- a/addons/pod-reaper/Chart.yaml
+++ b/addons/pod-reaper/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: A Helm chart for pod-reaper
+name: pod-reaper
+version: 0.1.0
+home: https://github.com/target/pod-reaper

--- a/addons/pod-reaper/README.md
+++ b/addons/pod-reaper/README.md
@@ -1,0 +1,29 @@
+# Pod Reaper Helm Chart
+
+This is a helm templated deployment for pod-reaper.
+
+## Chart details
+
+This chart will install a target/pod-reaper for an arbitrary number of configurations. 
+
+Installing the chart.
+```bash
+helm upgrade --install <deployment name> . -f values.yaml --namespace <namespace>
+```
+
+| Parameter                        | Description                                        | Default                       |
+| -------------------------------- | -------------------------------------------------- | ----------------------------- |
+| `image.repository`               | Image file location                                | `target/pod-reaper`         |
+| `image.tag`                      | Image tag                                          | `2.8.0`                          |
+| `resources`                      | Provides resource limits                           | ```
+|                                  |                                                    | limits:
+|                                  |                                                    |   cpu: 30m
+|                                  |                                                    |   memory: 30Mi
+|                                  |                                                    | requests:
+|                                  |                                                    |   cpu: 20m
+|                                  |                                                    |   memory: 20Mi
+|                                  |                                                    | ```                         |
+
+...
+
+

--- a/addons/pod-reaper/templates/deployment.yaml
+++ b/addons/pod-reaper/templates/deployment.yaml
@@ -1,0 +1,39 @@
+{{- range $k, $v := .Values.reapers }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Chart.Name }}-{{ $k }}
+  namespace: {{$.Release.Namespace}}
+  labels:
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}"
+    app: {{ $.Chart.Name }}-{{ $k }}
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+spec:
+  selector:
+    matchLabels:
+      app: {{ $.Chart.Name }}-{{ $k }}
+  template:
+    metadata:
+      labels:
+        app: {{ $.Chart.Name }}-{{ $k }}
+        release: {{ $.Release.Name }}
+    spec:
+      serviceAccountName: pod-reaper-service-account
+      containers:
+        - name: {{ $.Chart.Name }}
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          env:
+          {{- range $envkey, $envvalue := $v }}
+          {{- if $envvalue }}
+            - name: {{ upper $envkey}}
+              value: "{{$envvalue}}"
+          {{- end }}
+          {{- end }}
+          resources:
+{{ toYaml $.Values.resources | indent 12 }}
+
+---
+
+{{- end -}}

--- a/addons/pod-reaper/templates/rbac.yaml
+++ b/addons/pod-reaper/templates/rbac.yaml
@@ -1,0 +1,36 @@
+---
+# service account for running pod-reaper
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-reaper-service-account
+  namespace: {{.Release.Namespace}}
+
+---
+# minimal permissions required for running pod-reaper at cluster level
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-reaper-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "delete"]
+- apiGroups: [""]
+  resources: ["pods/eviction"]
+  verbs: ["create"]
+
+---
+# binding the above cluster role (permissions) to the above service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pod-reaper-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pod-reaper-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: pod-reaper-service-account
+  namespace: {{.Release.Namespace}}

--- a/addons/pod-reaper/values.yaml
+++ b/addons/pod-reaper/values.yaml
@@ -1,0 +1,39 @@
+# Default values for chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+image:
+  repository: target/pod-reaper
+  tag: 2.8.0
+
+# A set of named reapers
+# Example config:
+#
+#  test-reaper:
+#    namespace: "" # ie all
+#    grace_period: 10m
+#    schedule: "@every 1m"
+#    run_duration: "0s" # ie indefinitely
+#    exclude_label_key: ""
+#    exclude_label_values: ""
+#    require_label_key: ""
+#    require_label_values: ""
+#    require_annotation_key: ""
+#    require_annotation_values: ""
+#    dry_run: "false"
+#    max_pods: "0"
+#    log_level: "Info"
+#    log_format: "Logrus"
+#    chaos_chance: ""
+#    container_statuses: ""
+#    pod_statuses: ""
+#    max_duration: ""
+#    max_unready: ""
+reapers: {}
+
+resources:
+  limits:
+    cpu: 30m
+    memory: 30Mi
+  requests:
+    cpu: 20m
+    memory: 20Mi


### PR DESCRIPTION
Added https://github.com/target/pod-reaper to allow users to specify `Pod` lifetimes within their cluster.