### PR TITLE
HPAs for Blue/Green deployments

### DIFF
--- a/applications/web/templates/hpa-blue-green.yaml
+++ b/applications/web/templates/hpa-blue-green.yaml
@@ -1,5 +1,5 @@
 {{- if and (not $.Values.statefulset.enabled) $.Values.bluegreen.enabled -}}
-{{- if .Values.autoscaling.enabled }}
+{{- if $.Values.autoscaling.enabled }}
 {{- range $v, $tag := $.Values.bluegreen.imageTags }}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -10,10 +10,10 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "docker-template.fullname" . }}-{{ $tag }}
-  minReplicas: {{ .Values.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  minReplicas: {{ $.Values.autoscaling.minReplicas }}
+  maxReplicas: {{ $.Values.autoscaling.maxReplicas }}
   metrics:
-{{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
+{{- with $.Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
@@ -21,7 +21,7 @@ spec:
           type: Utilization
           averageUtilization: {{ . }}
 {{- end }}
-{{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- with $.Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu

--- a/applications/web/templates/hpa-blue-green.yaml
+++ b/applications/web/templates/hpa-blue-green.yaml
@@ -1,0 +1,33 @@
+{{- if and (not $.Values.statefulset.enabled) $.Values.bluegreen.enabled -}}
+{{- if .Values.autoscaling.enabled }}
+{{- range $v, $tag := $.Values.bluegreen.imageTags }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "docker-template.fullname" . }}-{{ $tag }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "docker-template.fullname" . }}-{{ $tag }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+{{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+{{- end }}
+{{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/applications/web/templates/hpa-blue-green.yaml
+++ b/applications/web/templates/hpa-blue-green.yaml
@@ -4,12 +4,12 @@
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "docker-template.fullname" . }}-{{ $tag }}
+  name: {{ include "docker-template.fullname" $ }}-{{ $tag }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "docker-template.fullname" . }}-{{ $tag }}
+    name: {{ include "docker-template.fullname" $ }}-{{ $tag }}
   minReplicas: {{ $.Values.autoscaling.minReplicas }}
   maxReplicas: {{ $.Values.autoscaling.maxReplicas }}
   metrics:

--- a/applications/web/templates/hpa-blue-green.yaml
+++ b/applications/web/templates/hpa-blue-green.yaml
@@ -31,3 +31,4 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}

--- a/applications/web/templates/hpa.yaml
+++ b/applications/web/templates/hpa.yaml
@@ -30,3 +30,4 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}

--- a/applications/web/templates/hpa.yaml
+++ b/applications/web/templates/hpa.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.bluegreen.enabled -}}
 {{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -26,5 +27,6 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ . }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/applications/web/templates/hpa.yaml
+++ b/applications/web/templates/hpa.yaml
@@ -30,4 +30,3 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- end }}


### PR DESCRIPTION
This PR rolls out a new `HorizontalPodAutoscaler` template meant just for blue/green deployments, as well as mods to the existing `HorizontalPodAutoscaler` to ensure that one's only used for traditional rolling deployments.