### PR TITLE
Remove pod revision from blue-green deployments

### DIFF
--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -144,8 +144,6 @@ spec:
                   fieldPath: status.podIP
             - name: PORTER_POD_IMAGE_TAG
               value: "{{ $tag }}"
-            - name: PORTER_POD_REVISION
-              value: "{{ $.Release.Revision }}"
             {{- range $key, $val := $.Values.container.env.normal }}
             - name: {{ $key }}
             {{- $splVal := split "_" $val -}}


### PR DESCRIPTION
Removes the `PORTER_POD_REVISION` environment variable from blue-green deployments.