### PR TITLE
rudimk/aws-alb-ingress -> dev

### DIFF
--- a/applications/web/templates/service.yaml
+++ b/applications/web/templates/service.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
   {{- end }}
 spec:
-  {{ if or .Values.ingress.enabled .Values.customNodePort.enabled }}
+  {{ if or .Values.ingress.enabled .Values.albIngress.enabled .Values.customNodePort.enabled }}
   type: NodePort
   {{ else }}
   type: ClusterIP


### PR DESCRIPTION
Modified the service template to ensure it creates a NodePort if NLB-based default Ingress is disabled, but ALB-based Ingress is enabled.