### PR TITLE
Add SGs and Target Type to ingress

### DIFF
--- a/applications/web/templates/alb-ingress.yaml
+++ b/applications/web/templates/alb-ingress.yaml
@@ -26,6 +26,10 @@ metadata:
     {{- if .Values.albIngress.certificate_arn }}
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.albIngress.certificate_arn }}
     {{- end }}
+    alb.ingress.kubernetes.io/target-type: {{ .Values.albIngress.target_type }}
+    {{- if .Values.albIngress.security_groups }}
+    alb.ingress.kubernetes.io/security-groups: {{ .Values.albIngress.security_groups }}
+    {{- end }}
 spec:
   rules:
   {{- range $allHosts }}

--- a/applications/web/templates/alb-ingress.yaml
+++ b/applications/web/templates/alb-ingress.yaml
@@ -30,6 +30,12 @@ metadata:
     {{- if .Values.albIngress.security_groups }}
     alb.ingress.kubernetes.io/security-groups: {{ .Values.albIngress.security_groups }}
     {{- end }}
+    {{- if .Values.albIngress.healthcheck_port }}
+    alb.ingress.kubernetes.io/healthcheck-port: {{ .Values.albIngress.healthcheck_port }}
+    {{- end }}
+    {{- if .Values.albIngress.healthcheck_protocol }}
+    alb.ingress.kubernetes.io/healthcheck-protocol: {{ .Values.albIngress.healthcheck_protocol }}
+    {{- end }}
 spec:
   rules:
   {{- range $allHosts }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -50,6 +50,8 @@ albIngress:
   group_name:
   target_type: ip
   security_groups:
+  healthcheck_port:
+  healthcheck_protocol:
 
 privateIngress:
   enabled: false

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -48,6 +48,8 @@ albIngress:
   certificate_arn:
   custom_paths: []
   group_name:
+  target_type: ip
+  security_groups:
 
 privateIngress:
   enabled: false


### PR DESCRIPTION
I have added to the ALBingress helm web template, the following annotations: 

- [target type](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/#target-type): specifies how to route traffic to pods. It is `instance` by default but using `ip`  reduces network hops and allow this to be extended to Fargate.
- [security groups](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/#security-groups): specifies the securityGroups you want to attach to LoadBalancer. The default creates a new SG open to the world and this allows to specify a SG with more restricted rules. 