### PR TITLE
feat(ALB ingress): enable scheme as value

### DIFF
--- a/applications/web/templates/alb-ingress.yaml
+++ b/applications/web/templates/alb-ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- if .Values.albIngress.group_name }}
     alb.ingress.kubernetes.io/group.name: {{ .Values.albIngress.group_name }}
     {{- end }}
-    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/scheme: {{ .Values.albIngress.scheme }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}, {"HTTP":80}]'
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
     {{- if .Values.albIngress.certificate_arn }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -49,6 +49,7 @@ albIngress:
   custom_paths: []
   group_name:
   target_type: ip
+  scheme: internet-facing
   security_groups:
   healthcheck_port:
   healthcheck_protocol:


### PR DESCRIPTION
We want to have the ability to expose web applications internally via the ALB ingress. 