### PR TITLE
Prevent replicas from being overwritten when keda autoscaling is enabled

### DIFF
--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -8,7 +8,9 @@ metadata:
     {{- include "docker-template.labels" $ | nindent 4 }}
 spec:
   {{- if not $.Values.autoscaling.enabled }}
+  {{- if not $.Values.keda.enabled -}}
   replicas: {{ $.Values.replicaCount }}
+  {{ end }}
   {{ end }}
   selector:
     matchLabels:

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -7,7 +7,9 @@ metadata:
     {{- include "docker-template.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
+  {{- if not .Values.keda.enabled -}}
   replicas: {{ .Values.replicaCount }}
+  {{ end }}
   {{ end }}
   selector:
     matchLabels:


### PR DESCRIPTION
When keda autoscaling is enabled, updates to the Helm chart cause the deployment's `spec.replicas` field to overwrite the autoscaling desired replica count. 

This PR prevents replicas from being set on the deployment when keda is enabled. 