### PR TITLE
Add missing attributes for health check

### DIFF
--- a/applications/web/templates/alb-ingress.yaml
+++ b/applications/web/templates/alb-ingress.yaml
@@ -30,6 +30,24 @@ metadata:
     {{- if .Values.albIngress.security_groups }}
     alb.ingress.kubernetes.io/security-groups: {{ .Values.albIngress.security_groups }}
     {{- end }}
+    {{- if .Values.albIngress.healthcheck_path }}
+    alb.ingress.kubernetes.io/healthcheck-path: {{ .Values.albIngress.healthcheck_path }}
+    {{- end }}
+    {{- if .Values.albIngress.healthcheck_interval_seconds }}
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: {{ .Values.albIngress.healthcheck_interval_seconds }}
+    {{- end }}
+    {{- if .Values.albIngress.healthcheck_timeout_seconds }}
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: {{ .Values.albIngress.healthcheck_timeout_seconds }}
+    {{- end }}
+    {{- if .Values.albIngress.healthcheck_success_codes }}
+    alb.ingress.kubernetes.io/success-codes: {{ .Values.albIngress.healthcheck_success_codes }}
+    {{- end }}
+    {{- if .Values.albIngress.healthcheck_healthy_threshold_count }}
+    alb.ingress.kubernetes.io/healthy-threshold-count: {{ .Values.albIngress.healthcheck_healthy_threshold_count }}
+    {{- end }}
+    {{- if .Values.albIngress.healthcheck_unhealthy_threshold_count }}
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: {{ .Values.albIngress.healthcheck_unhealthy_threshold_count }}
+    {{- end }}
     {{- if .Values.albIngress.healthcheck_port }}
     alb.ingress.kubernetes.io/healthcheck-port: {{ .Values.albIngress.healthcheck_port }}
     {{- end }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -51,6 +51,12 @@ albIngress:
   target_type: ip
   scheme: internet-facing
   security_groups:
+  healthcheck_path:
+  healthcheck_interval_seconds:
+  healthcheck_timeout_seconds:
+  healthcheck_success_codes:
+  healthcheck_healthy_threshold_count:
+  healthcheck_unhealthy_threshold_count:
   healthcheck_port:
   healthcheck_protocol:
 


### PR DESCRIPTION
Add missing attributes based on https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/ingress/annotations/#healthcheck-path
### Attributes:
- `alb.ingress.kubernetes.io/healthcheck-path` like `healthcheck_path`
- `healthcheck-interval-seconds` like `healthcheck_interval_seconds`
- `healthcheck-timeout-seconds` like `healthcheck_timeout_seconds`
- `success-codes` like `healthcheck_success_codes`
- `healthy-threshold-count` like `healthcheck_healthy_threshold_count`
- `unhealthy-threshold-count` like `healthcheck_unhealthy_threshold_count`