### PR TITLE
Add missing attributes for probes configuration

### DIFF
--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -81,9 +81,11 @@ spec:
                 - name: Authorization
                   value: Basic {{ printf "%s:%s" $.Values.health.livenessProbe.auth.username $.Values.health.livenessProbe.auth.password | b64enc }}
               {{ end }}
-            periodSeconds: {{ $.Values.health.livenessProbe.periodSeconds }}
-            failureThreshold: {{ $.Values.health.livenessProbe.failureThreshold }}
-            timeoutSeconds: {{ $.Values.health.livenessProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.health.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.health.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
           {{ end }}
           {{ if $.Values.health.livenessCommand.enabled }}
           livenessProbe:
@@ -92,8 +94,11 @@ spec:
                 {{- range $command := trim $.Values.health.livenessCommand.command | splitList " " }}
                 - {{ $command | quote }}
                 {{- end }}
-            initialDelaySeconds: {{ $.Values.health.livenessCommand.initialDelaySeconds }}
-            periodSeconds: {{ $.Values.health.livenessCommand.periodSeconds }}
+            initialDelaySeconds: {{ .Values.health.livenessCommand.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessCommand.periodSeconds }}
+            timeoutSeconds: {{ .Values.health.livenessCommand.timeoutSeconds }}
+            successThreshold: {{ .Values.health.livenessCommand.successThreshold }}
+            failureThreshold: {{ .Values.health.livenessCommand.failureThreshold }}
           {{ end }}
           {{ if $.Values.health.readinessProbe.enabled }}
           readinessProbe:
@@ -106,8 +111,11 @@ spec:
                 - name: Authorization
                   value: Basic {{ printf "%s:%s" $.Values.health.readinessProbe.auth.username $.Values.health.readinessProbe.auth.password | b64enc }}
               {{ end }}
-            periodSeconds: {{ $.Values.health.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ $.Values.health.readinessProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.health.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.health.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
           {{ end }}
           {{ if $.Values.health.startupProbe.enabled }}
           startupProbe:
@@ -120,9 +128,11 @@ spec:
                 - name: Authorization
                   value: Basic {{ printf "%s:%s" $.Values.health.startupProbe.auth.username $.Values.health.startupProbe.auth.password | b64enc }}
               {{ end }}
-            periodSeconds: {{ $.Values.health.startupProbe.periodSeconds }}
-            failureThreshold: {{ $.Values.health.startupProbe.failureThreshold }}
-            timeoutSeconds: {{ $.Values.health.startupProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.health.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.health.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.health.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}
           {{ end }}
           resources:
             requests:

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -92,9 +92,11 @@ spec:
                 - name: Authorization
                   value: Basic {{ printf "%s:%s" .Values.health.livenessProbe.auth.username .Values.health.livenessProbe.auth.password | b64enc }}
               {{ end }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
-            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.health.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.health.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
           {{ end }}
           {{ if .Values.health.livenessCommand.enabled }}
           livenessProbe:
@@ -105,6 +107,9 @@ spec:
                 {{- end }}
             initialDelaySeconds: {{ .Values.health.livenessCommand.initialDelaySeconds }}
             periodSeconds: {{ .Values.health.livenessCommand.periodSeconds }}
+            timeoutSeconds: {{ .Values.health.livenessCommand.timeoutSeconds }}
+            successThreshold: {{ .Values.health.livenessCommand.successThreshold }}
+            failureThreshold: {{ .Values.health.livenessCommand.failureThreshold }}
           {{ end }}
           {{ if .Values.health.readinessProbe.enabled }}
           readinessProbe:
@@ -117,8 +122,11 @@ spec:
                 - name: Authorization
                   value: Basic {{ printf "%s:%s" .Values.health.readinessProbe.auth.username .Values.health.readinessProbe.auth.password | b64enc }}
               {{ end }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.health.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.health.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
           {{ end }}
           {{ if .Values.health.startupProbe.enabled }}
           startupProbe:
@@ -131,9 +139,11 @@ spec:
                 - name: Authorization
                   value: Basic {{ printf "%s:%s" .Values.health.startupProbe.auth.username .Values.health.startupProbe.auth.password | b64enc }}
               {{ end }}
+            initialDelaySeconds: {{ .Values.health.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
-            failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.health.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.health.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}
           {{ end }}
           resources:
             requests:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -123,9 +123,11 @@ health:
     enabled: false
     path: "/livez"
     scheme: "HTTP"
+    initialDelaySeconds: 0
     periodSeconds: 5
-    failureThreshold: 3
     timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
     auth:
       enabled: false
       username: ""
@@ -134,15 +136,21 @@ health:
   livenessCommand:
     enabled: false
     command: "ls -l"
-    periodSeconds: 5
     initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
 
   readinessProbe:
     enabled: false
     path: "/readyz"
     scheme: "HTTP"
+    initialDelaySeconds: 0
     periodSeconds: 5
     timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
     auth:
       enabled: false
       username: ""


### PR DESCRIPTION
### Add missing attributes for probe configuration in deployment manifest
These changes add missing attributes with default values, based on the [official documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)

> [Probes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#probe-v1-core) have a number of fields that you can use to more precisely control the behavior of startup, liveness and readiness checks:

### Fields:
- `initialDelaySeconds`: Defaults to 0 seconds.
- `periodSeconds`: Default to 10 seconds.
- `timeoutSeconds`: Defaults to 1 second.
- `successThreshold`: Defaults to 1.
- `failureThreshold`: Defaults to 3

> **Note**: The changes keeps the default values already configured (`applications/web/values.yaml`)