### PR TITLE
Hotfix blue-green deployments

### DIFF
--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "docker-template.labels" $ | nindent 4 }}
 spec:
   {{- if not $.Values.autoscaling.enabled }}
-  {{- if not $.Values.keda.enabled -}}
+  {{- if not $.Values.keda.enabled }}
   replicas: {{ $.Values.replicaCount }}
   {{ end }}
   {{ end }}


### PR DESCRIPTION
Blue-green deployment manifests are currently broken due to addition removal template `-}}` 