### PR TITLE
Put `safe-to-evict` annotation in the correct `metadata` annotation

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -22,14 +22,15 @@ spec:
         {{- if .Values.stack.enabled }}
         porter.run/stack-name: "{{ .Values.stack.name }}"
         {{- end }}
-      annotations:
-        {{- if .Values.safeToEvict }}
-        "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
-        {{- else }}
-        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
-        {{- end }}
     spec:
       template:
+        metadata:
+          annotations:
+            {{- if .Values.safeToEvict }}
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
+            {{- else }}
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+            {{- end }}
         spec:
           containers:
           - name: {{ .Chart.Name }}


### PR DESCRIPTION
Safe-to-evict annotation was incorrectly set in the job's metadata rather than the pod metadata annotation. 