### PR TITLE
chore: add promtail config to track current revision in loki

### DIFF
--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -1,3 +1,133 @@
+# -- Section for crafting Promtails config file. The only directly relevant value is `config.file`
+# which is a templated string that references the other values and snippets below this key.
+# @default -- See `values.yaml`
+lokiConfig:
+  # -- The log level of the Promtail server
+  # Must be reference in `config.file` to configure `server.log_level`
+  # See default config in `values.yaml`
+  logLevel: info
+  # -- The port of the Promtail server
+  # Must be reference in `config.file` to configure `server.http_listen_port`
+  # See default config in `values.yaml`
+  serverPort: 3101
+  # -- The config of clients of the Promtail server
+  # Must be reference in `config.file` to configure `clients`
+  # @default -- See `values.yaml`
+  clients:
+    - url: http://{{ .Release.Name }}-loki.{{ .Release.Namespace }}:3100/loki/api/v1/push
+  # -- A section of reusable snippets that can be reference in `config.file`.
+  # Custom snippets may be added in order to reduce redundancy.
+  # This is especially helpful when multiple `kubernetes_sd_configs` are use which usually have large parts in common.
+  # @default -- See `values.yaml`
+  snippets:
+    pipelineStages:
+      - cri: {}
+    common:
+      - action: replace
+        source_labels:
+          - __meta_kubernetes_pod_annotation_helm_sh_revision
+        target_label: helm_sh_revision
+      - action: replace
+        source_labels:
+          - __meta_kubernetes_pod_node_name
+        target_label: node_name
+      - action: replace
+        source_labels:
+          - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        replacement: $1
+        separator: /
+        source_labels:
+          - namespace
+          - app
+        target_label: job
+      - action: replace
+        source_labels:
+          - __meta_kubernetes_pod_name
+        target_label: pod
+      - action: replace
+        source_labels:
+          - __meta_kubernetes_pod_container_name
+        target_label: container
+      - action: replace
+        replacement: /var/log/pods/*$1/*.log
+        separator: /
+        source_labels:
+          - __meta_kubernetes_pod_uid
+          - __meta_kubernetes_pod_container_name
+        target_label: __path__
+      - action: replace
+        replacement: /var/log/pods/*$1/*.log
+        regex: true/(.*)
+        separator: /
+        source_labels:
+          - __meta_kubernetes_pod_annotationpresent_kubernetes_io_config_hash
+          - __meta_kubernetes_pod_annotation_kubernetes_io_config_hash
+          - __meta_kubernetes_pod_container_name
+        target_label: __path__
+
+    # If set to true, adds an additional label for the scrape job.
+    # This helps debug the Promtail config.
+    addScrapeJobLabel: false
+
+    # -- You can put here any keys that will be directly added to the config file's 'limits_config' block.
+    # @default -- empty
+    extraLimitsConfig: ""
+
+    # -- You can put here any keys that will be directly added to the config file's 'server' block.
+    # @default -- empty
+    extraServerConfigs: ""
+
+    # -- You can put here any additional scrape configs you want to add to the config file.
+    # @default -- empty
+    extraScrapeConfigs: ""
+
+    # -- You can put here any additional relabel_configs to "kubernetes-pods" job
+    extraRelabelConfigs: []
+
+    scrapeConfigs: |
+      # See also https://github.com/grafana/loki/blob/master/production/ksonnet/promtail/scrape_config.libsonnet for reference
+      - job_name: kubernetes-pods
+        pipeline_stages:
+          {{- toYaml .Values.config.snippets.pipelineStages | nindent 2 }}
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels:
+              - __meta_kubernetes_pod_controller_name
+            regex: ([0-9a-z-.]+?)(-[0-9a-f]{8,10})?
+            action: replace
+            target_label: __tmp_controller_name
+          - source_labels:
+              - __meta_kubernetes_pod_label_app_kubernetes_io_name
+              - __meta_kubernetes_pod_label_app
+              - __tmp_controller_name
+              - __meta_kubernetes_pod_name
+            regex: ^;*([^;]+)(;.*)?$
+            action: replace
+            target_label: app
+          - source_labels:
+              - __meta_kubernetes_pod_label_app_kubernetes_io_instance
+              - __meta_kubernetes_pod_label_release
+            regex: ^;*([^;]+)(;.*)?$
+            action: replace
+            target_label: instance
+          - source_labels:
+              - __meta_kubernetes_pod_label_app_kubernetes_io_component
+              - __meta_kubernetes_pod_label_component
+            regex: ^;*([^;]+)(;.*)?$
+            action: replace
+            target_label: component
+          {{- if .Values.config.snippets.addScrapeJobLabel }}
+          - replacement: kubernetes-pods
+            target_label: scrape_job
+          {{- end }}
+          {{- toYaml .Values.config.snippets.common | nindent 2 }}
+          {{- with .Values.config.snippets.extraRelabelConfigs }}
+          {{- toYaml . | nindent 2 }}
+          {{- end }}
+
 agent:
   image: "public.ecr.aws/o1j4x7p4/porter-agent:v3"
   porterHost: "dashboard.getporter.dev"
@@ -46,14 +176,9 @@ loki:
       cpu: 100m
       memory: 1Gi
 
-
 promtail:
   enabled: true
-  config:
-    logLevel: info
-    serverPort: 3101
-    clients:
-      - url: http://{{ .Release.Name }}-loki.{{ .Release.Namespace }}:3100/loki/api/v1/push
+  config: {{- toYaml .Values.lokiConfig | nindent 2 }}
   resources:
     limits:
       memory: 256Mi

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -57,9 +57,11 @@ promtail:
     snippets:
       extraRelabelConfigs:
       - source_labels:
+          _ __meta_kubernetes_pod_node_name
           - __meta_kubernetes_pod_annotation_helm_sh_revision
-        target_label: helm_sh_revision
+        target_label: porter_pod_name
         action: replace
+        separator: '_'
   resources:
     limits:
       memory: 256Mi

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -57,7 +57,7 @@ promtail:
     snippets:
       extraRelabelConfigs:
       - source_labels:
-          _ __meta_kubernetes_pod_node_name
+          _ __meta_kubernetes_pod_name
           - __meta_kubernetes_pod_annotation_helm_sh_revision
         target_label: porter_pod_name
         action: replace

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -57,7 +57,7 @@ promtail:
     snippets:
       extraRelabelConfigs:
       - source_labels:
-          _ __meta_kubernetes_pod_name
+          - __meta_kubernetes_pod_name
           - __meta_kubernetes_pod_annotation_helm_sh_revision
         target_label: porter_pod_name
         action: replace

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -54,10 +54,12 @@ promtail:
     clients:
       - url: http://{{ .Release.Name }}-loki.{{ .Release.Namespace }}:3100/loki/api/v1/push
     # See https://github.com/grafana/helm-charts/blob/18282f1780c73130a89ba5e0ee0f8c5721f08b13/charts/promtail/values.yaml#L343
-    extraRelabelConfigs:
+    snippets:
+      extraRelabelConfigs:
       - source_labels:
           - __meta_kubernetes_pod_annotation_helm_sh_revision
         target_label: helm_sh_revision
+        action: replace
   resources:
     limits:
       memory: 256Mi

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -1,133 +1,3 @@
-# -- Section for crafting Promtails config file. The only directly relevant value is `config.file`
-# which is a templated string that references the other values and snippets below this key.
-# @default -- See `values.yaml`
-lokiConfig:
-  # -- The log level of the Promtail server
-  # Must be reference in `config.file` to configure `server.log_level`
-  # See default config in `values.yaml`
-  logLevel: info
-  # -- The port of the Promtail server
-  # Must be reference in `config.file` to configure `server.http_listen_port`
-  # See default config in `values.yaml`
-  serverPort: 3101
-  # -- The config of clients of the Promtail server
-  # Must be reference in `config.file` to configure `clients`
-  # @default -- See `values.yaml`
-  clients:
-    - url: http://{{ .Release.Name }}-loki.{{ .Release.Namespace }}:3100/loki/api/v1/push
-  # -- A section of reusable snippets that can be reference in `config.file`.
-  # Custom snippets may be added in order to reduce redundancy.
-  # This is especially helpful when multiple `kubernetes_sd_configs` are use which usually have large parts in common.
-  # @default -- See `values.yaml`
-  snippets:
-    pipelineStages:
-      - cri: {}
-    common:
-      - action: replace
-        source_labels:
-          - __meta_kubernetes_pod_annotation_helm_sh_revision
-        target_label: helm_sh_revision
-      - action: replace
-        source_labels:
-          - __meta_kubernetes_pod_node_name
-        target_label: node_name
-      - action: replace
-        source_labels:
-          - __meta_kubernetes_namespace
-        target_label: namespace
-      - action: replace
-        replacement: $1
-        separator: /
-        source_labels:
-          - namespace
-          - app
-        target_label: job
-      - action: replace
-        source_labels:
-          - __meta_kubernetes_pod_name
-        target_label: pod
-      - action: replace
-        source_labels:
-          - __meta_kubernetes_pod_container_name
-        target_label: container
-      - action: replace
-        replacement: /var/log/pods/*$1/*.log
-        separator: /
-        source_labels:
-          - __meta_kubernetes_pod_uid
-          - __meta_kubernetes_pod_container_name
-        target_label: __path__
-      - action: replace
-        replacement: /var/log/pods/*$1/*.log
-        regex: true/(.*)
-        separator: /
-        source_labels:
-          - __meta_kubernetes_pod_annotationpresent_kubernetes_io_config_hash
-          - __meta_kubernetes_pod_annotation_kubernetes_io_config_hash
-          - __meta_kubernetes_pod_container_name
-        target_label: __path__
-
-    # If set to true, adds an additional label for the scrape job.
-    # This helps debug the Promtail config.
-    addScrapeJobLabel: false
-
-    # -- You can put here any keys that will be directly added to the config file's 'limits_config' block.
-    # @default -- empty
-    extraLimitsConfig: ""
-
-    # -- You can put here any keys that will be directly added to the config file's 'server' block.
-    # @default -- empty
-    extraServerConfigs: ""
-
-    # -- You can put here any additional scrape configs you want to add to the config file.
-    # @default -- empty
-    extraScrapeConfigs: ""
-
-    # -- You can put here any additional relabel_configs to "kubernetes-pods" job
-    extraRelabelConfigs: []
-
-    scrapeConfigs: |
-      # See also https://github.com/grafana/loki/blob/master/production/ksonnet/promtail/scrape_config.libsonnet for reference
-      - job_name: kubernetes-pods
-        pipeline_stages:
-          {{- toYaml .Values.config.snippets.pipelineStages | nindent 2 }}
-        kubernetes_sd_configs:
-          - role: pod
-        relabel_configs:
-          - source_labels:
-              - __meta_kubernetes_pod_controller_name
-            regex: ([0-9a-z-.]+?)(-[0-9a-f]{8,10})?
-            action: replace
-            target_label: __tmp_controller_name
-          - source_labels:
-              - __meta_kubernetes_pod_label_app_kubernetes_io_name
-              - __meta_kubernetes_pod_label_app
-              - __tmp_controller_name
-              - __meta_kubernetes_pod_name
-            regex: ^;*([^;]+)(;.*)?$
-            action: replace
-            target_label: app
-          - source_labels:
-              - __meta_kubernetes_pod_label_app_kubernetes_io_instance
-              - __meta_kubernetes_pod_label_release
-            regex: ^;*([^;]+)(;.*)?$
-            action: replace
-            target_label: instance
-          - source_labels:
-              - __meta_kubernetes_pod_label_app_kubernetes_io_component
-              - __meta_kubernetes_pod_label_component
-            regex: ^;*([^;]+)(;.*)?$
-            action: replace
-            target_label: component
-          {{- if .Values.config.snippets.addScrapeJobLabel }}
-          - replacement: kubernetes-pods
-            target_label: scrape_job
-          {{- end }}
-          {{- toYaml .Values.config.snippets.common | nindent 2 }}
-          {{- with .Values.config.snippets.extraRelabelConfigs }}
-          {{- toYaml . | nindent 2 }}
-          {{- end }}
-
 agent:
   image: "public.ecr.aws/o1j4x7p4/porter-agent:v3"
   porterHost: "dashboard.getporter.dev"
@@ -178,7 +48,16 @@ loki:
 
 promtail:
   enabled: true
-  config: {{- toYaml .Values.lokiConfig | nindent 2 }}
+  config:
+    logLevel: info
+    serverPort: 3101
+    clients:
+      - url: http://{{ .Release.Name }}-loki.{{ .Release.Namespace }}:3100/loki/api/v1/push
+    # See https://github.com/grafana/helm-charts/blob/18282f1780c73130a89ba5e0ee0f8c5721f08b13/charts/promtail/values.yaml#L343
+    extraRelabelConfigs:
+      - source_labels:
+          - __meta_kubernetes_pod_annotation_helm_sh_revision
+        target_label: helm_sh_revision
   resources:
     limits:
       memory: 256Mi


### PR DESCRIPTION
# Description

This PR enables promtail to track annotations add the current revision at the pod level for us to implement it as a filter