### PR TITLE
Remove CPU request from `promtail` dependency

### DIFF
--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -78,5 +78,4 @@ promtail:
     limits:
       memory: 256Mi
     requests:
-      cpu: 100m
       memory: 256Mi


### PR DESCRIPTION
Remove request of `100m` for the CPU, as this can prevent promtail from getting scheduled. Usage should be low enough that the lack of this request won't cause throttling. 