### PR TITLE
Update promtail custom annotation to include `namespace`

### DIFF
--- a/addons/porter-agent/templates/deployment.yaml
+++ b/addons/porter-agent/templates/deployment.yaml
@@ -10,6 +10,8 @@ metadata:
   namespace: porter-agent-system
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -69,6 +69,7 @@ promtail:
     snippets:
       extraRelabelConfigs:
       - source_labels:
+          - __meta_kubernetes_namespace
           - __meta_kubernetes_pod_name
           - __meta_kubernetes_pod_annotation_helm_sh_revision
         target_label: porter_pod_name


### PR DESCRIPTION
Also switches porter-agent deployment strategy to `Recreate` to avoid multi-attach volume errors. 