### PR TITLE
Hotfix placement of topology spread constraints

### DIFF
--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -223,6 +223,22 @@ spec:
           operator: "Equal"
           value: "true"
           effect: "NoSchedule"
+      {{- if .Values.tolerations }}
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.topology.enabled }}
+      topologySpreadConstraints: 
+        - maxSkew: {{ .Values.topology.maxSkew }}
+          topologyKey: {{ .Values.topology.topologyKey }}
+          whenUnsatisfiable: {{ .Values.topology.whenUnsatisfiable }}
+          {{- if .Values.topology.labelSelector.enabled }}
+          labelSelector: 
+            matchLabels:
+              {{- range $k, $v := .Values.topology.labelSelector.matchLabels }}
+              {{ $k }}: {{ $v }}
+              {{- end }}
+          {{- end }}
+      {{ end }}
       {{ if or $.Values.pvc.enabled $.Values.cloudsql.enabled .Values.emptyDir.enabled }}
       volumes:
         {{ if $.Values.cloudsql.enabled }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -11,19 +11,6 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{ end }}
   {{ end }}
-  {{- if .Values.topology.enabled }}
-  topologySpreadConstraints: 
-    - maxSkew: {{ .Values.topology.maxSkew }}
-      topologyKey: {{ .Values.topology.topologyKey }}
-      whenUnsatisfiable: {{ .Values.topology.whenUnsatisfiable }}
-      {{- if .Values.topology.labelSelector.enabled }}
-      labelSelector: 
-        matchLabels:
-          {{- range $k, $v := .Values.topology.labelSelector.matchLabels }}
-          {{ $k }}: {{ $v }}
-          {{- end }}
-      {{- end }}
-  {{ end }}
   selector:
     matchLabels:
       {{- include "docker-template.selectorLabels" . | nindent 6 }}
@@ -268,6 +255,19 @@ spec:
       {{- if .Values.tolerations }}
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.topology.enabled }}
+      topologySpreadConstraints: 
+        - maxSkew: {{ .Values.topology.maxSkew }}
+          topologyKey: {{ .Values.topology.topologyKey }}
+          whenUnsatisfiable: {{ .Values.topology.whenUnsatisfiable }}
+          {{- if .Values.topology.labelSelector.enabled }}
+          labelSelector: 
+            matchLabels:
+              {{- range $k, $v := .Values.topology.labelSelector.matchLabels }}
+              {{ $k }}: {{ $v }}
+              {{- end }}
+          {{- end }}
+      {{ end }}
       {{ if or .Values.pvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled }}
       volumes:
         {{ if .Values.cloudsql.enabled }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -8,19 +8,6 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{ end }}
-  {{- if .Values.topology.enabled }}
-  topologySpreadConstraints: 
-    - maxSkew: {{ .Values.topology.maxSkew }}
-      topologyKey: {{ .Values.topology.topologyKey }}
-      whenUnsatisfiable: {{ .Values.topology.whenUnsatisfiable }}
-      {{- if .Values.topology.labelSelector.enabled }}
-      labelSelector: 
-        matchLabels:
-          {{- range $k, $v := .Values.topology.labelSelector.matchLabels }}
-          {{ $k }}: {{ $v }}
-          {{- end }}
-      {{- end }}
-  {{ end }}
   selector:
     matchLabels:
       {{- include "docker-template.selectorLabels" . | nindent 6 }}
@@ -195,6 +182,19 @@ spec:
       {{- if .Values.tolerations }}
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.topology.enabled }}
+      topologySpreadConstraints: 
+        - maxSkew: {{ .Values.topology.maxSkew }}
+          topologyKey: {{ .Values.topology.topologyKey }}
+          whenUnsatisfiable: {{ .Values.topology.whenUnsatisfiable }}
+          {{- if .Values.topology.labelSelector.enabled }}
+          labelSelector: 
+            matchLabels:
+              {{- range $k, $v := .Values.topology.labelSelector.matchLabels }}
+              {{ $k }}: {{ $v }}
+              {{- end }}
+          {{- end }}
+      {{ end }}
       {{ if or .Values.pvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled }}
       volumes:
         {{ if .Values.cloudsql.enabled }}


### PR DESCRIPTION
- `topologySpreadConstraints` should be placed inside `.spec.template.spec` rather than `.spec`. 
- constraints should be added to b/g deployment mechanism
- tolerations should be added to b/g deployment mechanism