### PR TITLE
Redis anti-eviction

### DIFF
--- a/addons/redis/templates/redis-master-statefulset.yaml
+++ b/addons/redis/templates/redis-master-statefulset.yaml
@@ -36,6 +36,7 @@ spec:
         checksum/health: {{ include (print $.Template.BasePath "/health-configmap.yaml") . | sha256sum }}
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       {{- if .Values.master.podAnnotations }}
       {{- toYaml .Values.master.podAnnotations | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
Added an annotation to ensure Redis Pods aren't taken down due to a scaleDown event undertaken by the cluster autoscaler.