### PR TITLE
KEDA - Datadog Secret bug

### DIFF
--- a/applications/web/templates/scaled-object-datadog-secret.yaml
+++ b/applications/web/templates/scaled-object-datadog-secret.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.keda.datadog.enabled -}}
+{{- $fullName := include "docker-template.fullname" . -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/applications/worker/templates/scaled-object-datadog-secret.yaml
+++ b/applications/worker/templates/scaled-object-datadog-secret.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.keda.datadog.enabled -}}
+{{- $fullName := include "docker-template.fullname" . -}}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Fixed a bug where the full release name wasn't being correctly referenced in KEDA's Datadog Secret manifest template.