### PR TITLE
Added a default false for the keda.datadog.enabled flag

### DIFF
--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -126,6 +126,8 @@ keda:
     metricName: ""
     metricQuery: ""
     metricThreshold: ""
+  datadog:
+    enabled: false
 
 health:
   livenessProbe:

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -72,6 +72,8 @@ keda:
     metricName: ""
     metricQuery: ""
     metricThreshold: ""
+  datadog:
+    enabled: false
 
 health:
   enabled: false


### PR DESCRIPTION
Added a default false for the keda.datadog.enabled flag; this will be extended when we get around to adding Datadog support for KEDA.

cc @mnafees 