### PR TITLE
CUS-56 Support deprecated GKE ingress class annotation

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -66,7 +66,9 @@ metadata:
 spec:
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 {{- if ne .Values.ingress.provider "azure" }}
+{{- if ne "gce" (index .Values.ingress.annotations "kubernetes.io/ingress.class" ) }}
   ingressClassName: nginx
+{{- end }}
 {{- end }}
 {{- end }}
   {{- if .Values.ingress.tls }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -46,9 +46,7 @@ ingress:
   custom_domain: false
   custom_paths: []
   rewriteCustomPathsEnabled: true
-  # annotations: {}
-  annotations: 
-    kubernetes.io/ingress.class: gce
+  annotations: {}
   wildcard: false
   tls: true
   useDefaultIngressTLSSecret: false

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -46,7 +46,9 @@ ingress:
   custom_domain: false
   custom_paths: []
   rewriteCustomPathsEnabled: true
-  annotations: {}
+  # annotations: {}
+  annotations: 
+    kubernetes.io/ingress.class: gce
   wildcard: false
   tls: true
   useDefaultIngressTLSSecret: false


### PR DESCRIPTION
**Summary**

Annotation `kubernetes.io/ingress.class` cannot be set at the same time as `ingressClassName` field in an ingress. Although the annotation is deprecated, [GKE still requires it](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#deprecated_annotation) when using their `gce` ingress class.

**Work items**
- Automatically remove `ingressClassName` when the annotation `kubernetes.io/ingress.class` is `gce`