### PR TITLE
perf(Datadog traces): enable datadog traces

### DIFF
--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -128,6 +128,12 @@ spec:
               value: {{ quote $val }}
             {{- end }}
             {{- end }}
+            {{ if .Values.datadog.enabled }}
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            {{ end }}
             {{- range $syncedEnv := .Values.container.env.synced }}
             {{- range $key := $syncedEnv.keys }}
             - name: {{ $key.name }}

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -101,6 +101,9 @@ cloudsql:
   dbPort: 5432
   serviceAccountJSON: ""
 
+datadog:
+  enabled: false
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
As per web applications, workers also need datadog trace instrumentation to instrument there api calls to other services. 

I am not sure, whether this makes a conflict with keda.datadog configuration. 