### PR TITLE
Fixing Job/CronJob ServiceAccounts

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -32,6 +32,7 @@ spec:
             "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
             {{- end }}
         spec:
+          serviceAccountName: {{ include "docker-template.serviceAccountName" . }}
           containers:
           - name: {{ .Chart.Name }}
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/applications/job/templates/serviceaccount.yaml
+++ b/applications/job/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "docker-template.serviceAccountName" . }}
+  name: cronjob-{{ include "docker-template.serviceAccountName" . }}
   labels:
     {{- include "docker-template.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
This PR fixes a couple of issues with `ServiceAccounts` for `Jobs`, introduced in PR #565.

1. We now inject the new `ServiceAccount`'s name into the `CronJob` manifest.
2. `ServiceAccounts` for `Jobs`/`CronJobs` now have the `cronjob-` prefix, in order to avoid conflicts with the default `ServiceAccount` that's created for a `Job` hook.