### PR TITLE
Cronjob <-> ServiceAccount reference fix

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -32,7 +32,7 @@ spec:
             "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
             {{- end }}
         spec:
-          serviceAccountName: {{ include "docker-template.serviceAccountName" . }}
+          serviceAccountName: cronjob-{{ include "docker-template.serviceAccountName" . }}
           containers:
           - name: {{ .Chart.Name }}
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Pushing a fix for the incorrect ServiceAccount name being referenced by the CronJob template.