### PR TITLE
ServiceAccounts for manual job runs

### DIFF
--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -48,6 +48,7 @@ data:
               operator: "Equal"
               value: "true"
               effect: "NoSchedule"
+          serviceAccountName: cronjob-{{ include "docker-template.serviceAccountName" . }}
           containers:
           - name: {{ .Chart.Name }}
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/applications/job/templates/hook-serviceaccount.yaml
+++ b/applications/job/templates/hook-serviceaccount.yaml
@@ -3,11 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "docker-template.fullname" . }}
-  {{- if .Values.serviceAccount.create -}}
-  {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- end }}
 automountServiceAccountToken: true
 {{- end }}


### PR DESCRIPTION
This PR nails adding ServiceAccounts with custom annotations for manually-triggered `Jobs` as well as `CronJobs`. What happens now - when `.Values.serviceAccount.create` is set to `true`, a new `ServiceAccount` is created. The same `ServiceAccount` is now injected into `cronjob.yaml`(for scheduled jobs) and `hook-configmap.yaml`(for manually-triggered job runs).