### PR TITLE
[porter-agent] Add values for compactor and `CF_ACCESS_TOKEN`

### DIFF
--- a/addons/porter-agent/templates/configmap.yaml
+++ b/addons/porter-agent/templates/configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: porter-agent-system
 data:
   PORTER_HOST: "{{ .Values.agent.porterHost }}"
+  CF_ACCESS_TOKEN: "{{ .Values.agent.cfAccessToken }}"
   PORTER_PORT: "{{ .Values.agent.porterPort }}"
   PORTER_TOKEN: "{{ .Values.agent.porterToken }}"
   CLUSTER_ID: "{{ .Values.agent.clusterID }}"

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -1,5 +1,6 @@
 agent:
-  image: "public.ecr.aws/o1j4x7p4/porter-agent:latest"
+  image: "public.ecr.aws/o1j4x7p4/porter-agent:v3"
+  cfAccessToken: ""
   porterHost: "dashboard.getporter.dev"
   porterPort: "80"
   porterToken: ""
@@ -13,11 +14,11 @@ agent:
 
 resources:
   limits:
-    cpu: 100m
-    memory: 256Mi
+    cpu: 500m
+    memory: 1024Mi
   requests:
-    cpu: 100m
-    memory: 256Mi
+    cpu: 500m
+    memory: 1024Mi
 
 nodeSelector: {}
 tolerations: []
@@ -26,11 +27,15 @@ loki:
   enabled: true
   isDefault: true
   config:
+    compactor:
+      retention_enabled: true
+      retention_delete_delay: 0h
     limits_config:
       reject_old_samples: true
       # reject samples older than one week
       reject_old_samples_max_age: 168h
       max_concurrent_tail_requests: 50
+      retention_period: 168h
     table_manager:
       retention_deletes_enabled: true
       retention_period: 168h
@@ -56,10 +61,11 @@ loki:
     size: 100Gi
   resources:
     limits:
-      memory: 1Gi
+      cpu: 500m
+      memory: 1024Mi
     requests:
-      cpu: 100m
-      memory: 1Gi
+      cpu: 500m
+      memory: 1024Mi
 
 promtail:
   enabled: true


### PR DESCRIPTION
- defaults to using the `v3` image tag for the agent
- adds support for `CF_ACCESS_TOKEN`
- adds compactor default config
- increases resource for the controller manager