### PR TITLE
chore(ALBIngress): add target node labels annotation

### DIFF
--- a/applications/web/templates/alb-ingress.yaml
+++ b/applications/web/templates/alb-ingress.yaml
@@ -54,6 +54,9 @@ metadata:
     {{- if .Values.albIngress.healthcheck_protocol }}
     alb.ingress.kubernetes.io/healthcheck-protocol: {{ .Values.albIngress.healthcheck_protocol }}
     {{- end }}
+    {{- if .Values.albIngress.target_node_labels }}
+    alb.ingress.kubernetes.io/target-node-labels: {{ .Values.albIngress.target_node_labels }}
+    {{- end }}
 spec:
   rules:
   {{- range $allHosts }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -70,6 +70,7 @@ albIngress:
   healthcheck_unhealthy_threshold_count:
   healthcheck_port:
   healthcheck_protocol:
+  target_node_labels: 
 
 privateIngress:
   enabled: false


### PR DESCRIPTION
Adding [target node labels annotation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/ingress/annotations/#target-node-labels) to set the nodes that the ALB will send traffic. 

This will reduce 504 errors when spot and od nodes co-live. 

