### PR TITLE
Setting dogstatsd in the Datadog addon to use a HostPort.

### DIFF
--- a/addons/datadog/values.yaml
+++ b/addons/datadog/values.yaml
@@ -313,7 +313,7 @@ datadog:
     ##
     ## WARNING: Make sure that hosts using this are properly firewalled otherwise
     ## metrics and traces are accepted from any host able to connect to this host.
-    useHostPort: false
+    useHostPort: true
 
     # datadog.dogstatsd.useHostPID -- Run the agent in the host's PID namespace
     ## DEPRECATED: use datadog.useHostPID instead.


### PR DESCRIPTION
This PR adds a fix to the Datadog Helm chart addon, and configures DogstatsD to use a `HostPort`. It fixes an issue where APM metrics were not being collected in totality for user workloads.