### PR TITLE
LogDNA - addon updates

### DIFF
--- a/addons/datadog/values.yaml
+++ b/addons/datadog/values.yaml
@@ -755,7 +755,7 @@ datadog:
   # Autodiscovery, as a space-sepatered list
 
   ## ref: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent#exclude-containers
-  containerExclude: 'kube_namespace:cert-manager kube_namespace:kube-system kube_namespace:monitoring kube_namespace:porter-agent-system'
+  containerExclude: 'kube_namespace:cert-manager kube_namespace:ingress-nginx kube_namespace:kube-system kube_namespace:monitoring kube_namespace:porter-agent-system'
 
   # datadog.containerInclude -- Include containers in the Agent Autodiscovery,
   # as a space-separated list.  If a container matches an include rule, it’s
@@ -766,7 +766,7 @@ datadog:
 
   # datadog.containerExcludeLogs -- Exclude logs from the Agent Autodiscovery,
   # as a space-separated list
-  containerExcludeLogs: 'kube_namespace:cert-manager kube_namespace:kube-system kube_namespace:monitoring kube_namespace:porter-agent-system'
+  containerExcludeLogs: 'kube_namespace:cert-manager kube_namespace:ingress-nginx kube_namespace:kube-system kube_namespace:monitoring kube_namespace:porter-agent-system'
 
   # datadog.containerIncludeLogs -- Include logs in the Agent Autodiscovery, as
   # a space-separated list
@@ -774,7 +774,7 @@ datadog:
 
   # datadog.containerExcludeMetrics -- Exclude metrics from the Agent
   # Autodiscovery, as a space-separated list
-  containerExcludeMetrics: 'kube_namespace:cert-manager kube_namespace:kube-system kube_namespace:monitoring kube_namespace:porter-agent-system'
+  containerExcludeMetrics: 'kube_namespace:cert-manager kube_namespace:ingress-nginx kube_namespace:kube-system kube_namespace:monitoring kube_namespace:porter-agent-system'
 
   # datadog.containerIncludeMetrics -- Include metrics in the Agent
   # Autodiscovery, as a space-separated list

--- a/addons/logdna/Chart.yaml
+++ b/addons/logdna/Chart.yaml
@@ -1,24 +1,23 @@
 apiVersion: v2
-appVersion: 3.1.0
+appVersion: 3.8.2
 description: LogDNA collector agent daemonset for Kubernetes.
 home: https://logdna.com
-icon: https://user-images.githubusercontent.com/65516095/118185526-a2447480-b40a-11eb-9bdb-82aa0a306f26.png
+icon: https://logdna.com/assets/images/logdna_logo_240w.png
 keywords:
-  - logs
-  - logging
-  - log-management
-  - agent
-  - alerts
-  - metric
-  - metrics
-  - events
-  - daemonset
-  - logger
+- logs
+- logging
+- log-management
+- agent
+- alerts
+- metrics
+- events
+- daemonset
+- logger
 maintainers:
-  - email: help@logdna.com
-    name: LogDNA
-name: logdna
+- email: help@logdna.com
+  name: LogDNA
+name: agent
 sources:
-  - https://github.com/logdna/logdna-agent-v2
+- https://github.com/logdna/logdna-agent-v2
 type: application
-version: 0.9.0
+version: 203.8.2

--- a/addons/logdna/README.md
+++ b/addons/logdna/README.md
@@ -52,7 +52,7 @@ Parameter | Description | Default
 `logdna.key` | LogDNA Ingestion Key (Required) | None
 `logdna.tags` | Optional tags such as `production` | None
 `priorityClassName` | (Optional) Set a PriorityClass on the Daemonset | `""`
-`resources.limits.memory` | Memory resource limits | 75Mi
+`resources.limits.memory` | Memory resource limits |500Mi
 `updateOnSecretChange` | Optionally set annotation on daemonset to cause deploy when secret changes | None
 `extraEnv` | Additional environment variables | `{}`
 `extraVolumeMounts` | Additional Volume mounts | `[]`

--- a/addons/logdna/templates/daemon_set.yaml
+++ b/addons/logdna/templates/daemon_set.yaml
@@ -89,8 +89,6 @@ spec:
           - name: mnt
             mountPath: /mnt
             readOnly: true
-          - name: docker
-            mountPath: /var/run/docker.sock
           - name: osrelease
             mountPath: /etc/os-release
           - name: logdnahostname
@@ -111,9 +109,6 @@ spec:
         - name: mnt
           hostPath:
             path: /mnt
-        - name: docker
-          hostPath:
-            path: /var/run/docker.sock
         - name: osrelease
           hostPath:
             path: /etc/os-release

--- a/addons/logdna/values.yaml
+++ b/addons/logdna/values.yaml
@@ -5,20 +5,15 @@ image:
 
 logdna:
   name: logdna-agent
-  key: ""
 
 resources:
   requests:
     cpu: 20m
   limits:
-    memory: 75Mi
+    memory: 500Mi
 
 daemonset:
-  tolerations:
-    - effect: NoSchedule
-      key: removable
-      operator: Equal
-      value: 'true'
+  tolerations: []
 
 priorityClassName: ""
 extraEnv: {}

--- a/addons/logdna/values.yaml
+++ b/addons/logdna/values.yaml
@@ -5,6 +5,7 @@ image:
 
 logdna:
   name: logdna-agent
+  key: ""
 
 resources:
   requests:

--- a/addons/logdna/values.yaml
+++ b/addons/logdna/values.yaml
@@ -25,7 +25,7 @@ extraEnv:
   - name: LOGDNA_USE_K8S_LOG_ENRICHMENT
     value: "always"
   - name: LOGDNA_K8S_METADATA_LINE_EXCLUSION
-    value: "namespace:cert-manager, namespace:kube-system, namespace:monitoring, namespace:porter-agent-system, label.app.kubernetes.io/instance:aws-vpc-cni"
+    value: "namespace:cert-manager, namespace:ingress-nginx, namespace:kube-system, namespace:monitoring, namespace:porter-agent-system, label.app.kubernetes.io/instance:aws-vpc-cni"
   - name: LOGDNA_EXCLUSION_RULES
     value: "/var/log/chrony/**, /var/log/aws-routed-eni/**"
 

--- a/addons/logdna/values.yaml
+++ b/addons/logdna/values.yaml
@@ -26,6 +26,8 @@ extraEnv:
     value: "always"
   - name: LOGDNA_K8S_METADATA_LINE_EXCLUSION
     value: "namespace:cert-manager, namespace:kube-system, namespace:monitoring, namespace:porter-agent-system, label.app.kubernetes.io/instance:aws-vpc-cni"
+  - name: LOGDNA_EXCLUSION_RULES
+    value: "/var/log/chrony/**, /var/log/aws-routed-eni/**"
 
 extraVolumeMounts: []
 extraVolumes: []

--- a/addons/logdna/values.yaml
+++ b/addons/logdna/values.yaml
@@ -14,10 +14,19 @@ resources:
     memory: 500Mi
 
 daemonset:
-  tolerations: []
+  tolerations:
+    - effect: NoSchedule
+      key: porter.run/workload-kind
+      value: "system"
+      operator: Equal
 
 priorityClassName: ""
-extraEnv: {}
+extraEnv:
+  - name: LOGDNA_USE_K8S_LOG_ENRICHMENT
+    value: "always"
+  - name: LOGDNA_K8S_METADATA_LINE_EXCLUSION
+    value: "namespace:cert-manager, namespace:kube-system, namespace:monitoring, namespace:porter-agent-system, label.app.kubernetes.io/instance:aws-vpc-cni"
+
 extraVolumeMounts: []
 extraVolumes: []
 


### PR DESCRIPTION
This PR bumps up the LogDNA addon to chart version 203.8.2(app version 3.8.2). It also introduces exclusion rules for removing verbose logging from system components.