### PR TITLE
Pull latest tag not v3

### DIFF
--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -1,5 +1,5 @@
 agent:
-  image: "public.ecr.aws/o1j4x7p4/porter-agent:v3"
+  image: "public.ecr.aws/o1j4x7p4/porter-agent:latest"
   cfAccessToken: ""
   porterHost: "dashboard.getporter.dev"
   porterPort: "80"


### PR DESCRIPTION
I want to test things on the v3/main branch and I noticed that this is still set to pull from :v3 rather than :latest.  Reverting this unless there was a reason to keep it at v3.