### PR TITLE
Allow setting metricType on ScaledObject

### DIFF
--- a/applications/web/templates/scaled-object.yaml
+++ b/applications/web/templates/scaled-object.yaml
@@ -34,6 +34,7 @@ spec:
             periodSeconds: {{ .Values.keda.hpa.scaleDown.policy.periodSeconds }}
   triggers:
     - type: prometheus
+      metricType: {{ .Values.keda.trigger.metricType | default "AverageValue" }}
       metadata:
         # Required fields:
         serverAddress: http://prometheus-server.monitoring.svc.cluster.local:80

--- a/applications/worker/templates/scaled-object.yaml
+++ b/applications/worker/templates/scaled-object.yaml
@@ -34,6 +34,7 @@ spec:
             periodSeconds: {{ .Values.keda.hpa.scaleDown.policy.periodSeconds }}
   triggers:
     - type: prometheus
+      metricType: {{ .Values.keda.trigger.metricType | default "AverageValue" }}
       metadata:
         # Required fields:
         serverAddress: http://prometheus-server.monitoring.svc.cluster.local:80


### PR DESCRIPTION
KEDA has had the ability to specify the `metricType` on the trigger since v2.7. It defaults to `AverageValue` which averages the given metric across all pods. A metricType of `Value` can also be used when averaging isn't desired. This adds the ability to set the `metricType` and defaults it to `AverageValue` to maintain backwards compatibility.

More info:
https://keda.sh/docs/2.5/faq/#what-does-the-target-metric-value-in-the-horizontal-pod-autoscaler-hpa-represent
https://keda.sh/docs/2.7/concepts/scaling-deployments/#triggers
https://github.com/kedacore/keda/pull/2309