### PR TITLE
refactor(alb-ingress): Update static value of pathType attribute

### DIFF
--- a/applications/web/templates/alb-ingress.yaml
+++ b/applications/web/templates/alb-ingress.yaml
@@ -61,7 +61,7 @@ spec:
           {{- range $customPaths }}
           - path: {{ .path }}
             {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-            pathType: ImplementationSpecific
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
             {{- end }}
             backend:
             {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
@@ -77,7 +77,7 @@ spec:
           {{ else }}
           - path: /*
             {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-            pathType: ImplementationSpecific
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
             {{- end }}
             backend:
             {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}


### PR DESCRIPTION
### Changes:
- Enable custom value for `pathType` attribute, related to [this issue](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2203).