### PR TITLE
NewRelic - fixes

### DIFF
--- a/addons/nri-bundle/Chart.yaml
+++ b/addons/nri-bundle/Chart.yaml
@@ -17,6 +17,7 @@ sources:
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
 
 version: 5.0.15
+appVersion: 5.0.15
 
 dependencies:
   - name: newrelic-infrastructure

--- a/addons/nri-bundle/form.yaml
+++ b/addons/nri-bundle/form.yaml
@@ -49,6 +49,6 @@ tabs:
           - type: subtitle
             label: Enable NewRelic's K8s Metrics Adapter for custom queries
           - type: checkbox
-            label: Enable kube-events
+            label: Enable newrelic-k8s-metrics-adapter
             variable: newrelic-k8s-metrics-adapter.enabled
           


### PR DESCRIPTION
This PR introduces a couple of quick fixes:

1. Added an `appVersion` to the chart, and set it to the same version exposed by `version`.
2. Fixed a typo in the addon's form, where the switch for the K8s Metrics Adapter was incorrectly labeled.