### PR TITLE
NewRelic - Metrics Adapter fixes

### DIFF
--- a/addons/nri-bundle/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/README.md
+++ b/addons/nri-bundle/charts/newrelic-k8s-metrics-adapter/templates/apiservice/job-patch/README.md
@@ -1,3 +1,0 @@
-The manifests in this directory are modified version of the manifests coming from
-the [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/f1729dcfd2040660d4f3dcbe3b2f797415990711/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch)
-Helm chart.


### PR DESCRIPTION
Removed a README that was preventing the metrics adapter from being deployed.