### PR TITLE
Support CronJobs for EKS/GKE 1.25+

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -3,6 +3,7 @@
 apiVersion: batch/v1
 {{- else }}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ include "docker-template.fullname" . }}

--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -1,4 +1,7 @@
 {{- if or (ne .Values.image.repository "public.ecr.aws/o1j4x7p4/hello-porter-job") (.Values.global) }}
+{{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" }}
+apiVersion: batch/v1
+{{- else }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:


### PR DESCRIPTION
Added some conditional logic to the job chart's CronJob template to check if `batch/v1/CronJob` exists, and to use `batch/v1beta1/CronJob` if needed.