### PR TITLE
fix: ALB Ingress group.order annotation type

### DIFF
--- a/applications/web/templates/alb-ingress.yaml
+++ b/applications/web/templates/alb-ingress.yaml
@@ -15,7 +15,7 @@ metadata:
     alb.ingress.kubernetes.io/group.name: {{ .Values.albIngress.group_name }}
     {{- end }}
     {{- if .Values.albIngress.group_order }}
-    alb.ingress.kubernetes.io/group.order: {{ .Values.albIngress.group_order }}
+    alb.ingress.kubernetes.io/group.order: '{{ .Values.albIngress.group_order }}'
     {{- end }}
     alb.ingress.kubernetes.io/scheme: {{ .Values.albIngress.scheme }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}, {"HTTP":80}]'


### PR DESCRIPTION
We kept getting this error whenever trying to apply a specific group order value:
```
unable to decode "": json: cannot unmarshal number into Go struct field ObjectMeta.metadata.annotations of type string
```