### PR TITLE
HPA API version updates

### DIFF
--- a/applications/web/templates/hpa-blue-green.yaml
+++ b/applications/web/templates/hpa-blue-green.yaml
@@ -1,7 +1,11 @@
 {{- if and (not $.Values.statefulset.enabled) $.Values.bluegreen.enabled -}}
 {{- if $.Values.autoscaling.enabled }}
 {{- range $v, $tag := $.Values.bluegreen.imageTags }}
+{{- if $.Capabilities.APIVersions.Has "autoscaling/v2" }}
+apiVersion: autoscaling/v2
+{{- else }}
 apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "docker-template.fullname" $ }}-{{ $tag }}

--- a/applications/web/templates/hpa.yaml
+++ b/applications/web/templates/hpa.yaml
@@ -1,6 +1,10 @@
 {{- if not .Values.bluegreen.enabled -}}
 {{- if .Values.autoscaling.enabled }}
+{{- if $.Capabilities.APIVersions.Has "autoscaling/v2" }}
+apiVersion: autoscaling/v2
+{{- else }}
 apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "docker-template.fullname" . }}

--- a/applications/worker/templates/hpa.yaml
+++ b/applications/worker/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
+{{- if $.Capabilities.APIVersions.Has "autoscaling/v2" }}
+apiVersion: autoscaling/v2
+{{- else }}
 apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "docker-template.fullname" . }}


### PR DESCRIPTION
Updated `HorizontalPodAutoscaler` templates to use the new `autoscaling/v2` API version if it's available, else default to `autoscaling/v2beta2`.