### PR TITLE
Setting Host Aliases

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -41,6 +41,8 @@ spec:
           {{ else }}
           serviceAccountName: {{ include "docker-template.serviceAccountName" . }}
           {{- end }}
+          hostAliases:
+            {{- toYaml .Values.hostAliases | nindent 10 }}
           containers:
           - name: {{ .Chart.Name }}
             {{ if .Values.global}}

--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -53,6 +53,8 @@ data:
           {{ else }}
           serviceAccountName: {{ include "docker-template.serviceAccountName" . }}
           {{- end }}
+          hostAliases:
+            {{- toYaml .Values.hostAliases | nindent 10 }}
           containers:
           - name: {{ .Chart.Name }}
             {{ if .Values.global}}

--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -59,6 +59,7 @@ sidecar:
       memory: 10Mi
 
 # Set this to add entries to the /etc/hosts file
+# Format: hostAliases: [{ip: <IP>, hostnames: [<HOSTNAME>,..]},..]
 hostAliases: []
 
 retainFailedHooks: false

--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -58,6 +58,9 @@ sidecar:
       cpu: 10m
       memory: 10Mi
 
+# Set this to add entries to the /etc/hosts file
+hostAliases: []
+
 retainFailedHooks: false
 nodeSelector: {}
 tolerations: []

--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -28,6 +28,8 @@ spec:
     spec:
       serviceAccountName: {{ include "docker-template.serviceAccountName" $ }}
       terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds }}
+      hostAliases:
+        {{- toYaml .Values.hostAliases | nindent 8 }}
       securityContext:
         {{- toYaml $.Values.podSecurityContext | nindent 8 }}
       containers:

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "docker-template.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      hostAliases:
+        {{- toYaml .Values.hostAliases | nindent 8 }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -203,6 +203,7 @@ datadog:
   enabled: false
 
 # Set this to add entries to the /etc/hosts file
+# Format: hostAliases: [{ip: <IP>, hostnames: [<HOSTNAME>,..]},..]
 hostAliases: []
 
 nodeSelector: {}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -202,6 +202,9 @@ cloudsql:
 datadog:
   enabled: false
 
+# Set this to add entries to the /etc/hosts file
+hostAliases: []
+
 nodeSelector: {}
 
 tolerations: []

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "docker-template.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      hostAliases:
+        {{- toYaml .Values.hostAliases | nindent 8 }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -106,6 +106,9 @@ cloudsql:
   dbPort: 5432
   serviceAccountJSON: ""
 
+# Set this to add entries to the /etc/hosts file
+hostAliases: []
+
 nodeSelector: {}
 
 tolerations: []

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -107,6 +107,7 @@ cloudsql:
   serviceAccountJSON: ""
 
 # Set this to add entries to the /etc/hosts file
+# Format: hostAliases: [{ip: <IP>, hostnames: [<HOSTNAME>,..]},..]
 hostAliases: []
 
 nodeSelector: {}


### PR DESCRIPTION
Since EKS clusters are facing trouble resolving/tracing dual-stack DNS endpoints reliably, this PR introduces the ability to set `hostAliases` as Helm values for `web`, `worker` and `job` charts - it's the same as manually setting entries in `/etc/hosts`.

To set `hostAliases`, add the following to the Helm values:

```yaml
hostAliases:
  - ip: "W.X.Y.Z"
    hostnames:
      - "HOSTNAME"
```