### PR TITLE
Added support for enabling TLS on private Ingress endpoints.

### DIFF
--- a/applications/web/templates/private-ingress.yaml
+++ b/applications/web/templates/private-ingress.yaml
@@ -17,6 +17,11 @@ metadata:
     {{- if and (gt (len $customPaths) 0) .Values.ingress.rewriteCustomPathsEnabled }}
     nginx.ingress.kubernetes.io/rewrite-target: /
     {{- end }}
+    {{- if .Values.privateIngress.tls }}
+    {{- if not (hasKey .Values.privateIngress.annotations "cert-manager.io/cluster-issuer")}}
+    cert-manager.io/cluster-issuer: {{ .Values.privateIngress.clusterIssuer }}
+    {{- end }}
+    {{- end }}
     # provider-agnostic default annotations
     # if value is provided as "null" or null, it is unset
     # adding a fix for scenarios where ingress annotations are inside ingress.annotations.normal

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -80,7 +80,7 @@ privateIngress:
   custom_paths: []
   annotations: {}
   tls: false
-  # secretName: my-existing-secret
+  clusterIssuer: letsencrypt-prod-private
 
 container:
   port: 80


### PR DESCRIPTION
This PR adds support for enabling TLS on private `Ingress` endpoints. It assumes the presence of a `ClusterIssuer` that uses DNS-01 challenges; while such a `ClusterIssuer` is named `letsencrypt-prod-private` by default, this can be overriden inside `.Values.privateIngress.clusterIssuer`. 