### PR TITLE
KEDA + B/G Deployments - Tagged ScaledObjects

### DIFF
--- a/applications/web/templates/scaled-object-blue-green.yaml
+++ b/applications/web/templates/scaled-object-blue-green.yaml
@@ -5,7 +5,7 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ $fullName }}
+  name: {{ $fullName }}-{{ $tag }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
Quick fix - for KEDA + B/G deployments, adding the deployment tag to the name of the ScaledObject.