### PR TITLE
Keda + B/G fixes II

### DIFF
--- a/applications/web/templates/scaled-object-blue-green.yaml
+++ b/applications/web/templates/scaled-object-blue-green.yaml
@@ -1,5 +1,5 @@
 {{- if and (not $.Values.statefulset.enabled) $.Values.bluegreen.enabled -}}
-{{- if $.Values.keda.enabled -}}
+{{- if $.Values.keda.enabled }}
 {{- range $v, $tag := $.Values.bluegreen.imageTags }}
 {{- $fullName := include "docker-template.fullname" $ -}}
 apiVersion: keda.sh/v1alpha1
@@ -42,6 +42,9 @@ spec:
         metricName: {{ $.Values.keda.trigger.metricName }}
         query: {{ $.Values.keda.trigger.metricQuery }}
         threshold: '{{ $.Values.keda.trigger.metricThreshold }}'
+{{- if not (eq $v (sub (len $.Values.bluegreen.imageTags) 1) ) }}
+---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Added a delimiter for multiple ScaledObject manifests generated in a B/G deployment.