### PR TITLE
Synchronizing KEDA replica counts during B/G deployments

### DIFF
--- a/applications/web/templates/scaled-object-blue-green.yaml
+++ b/applications/web/templates/scaled-object-blue-green.yaml
@@ -30,11 +30,11 @@ spec:
             value: {{ $.Values.keda.hpa.scaleUp.policy.value }}
             periodSeconds: {{ $.Values.keda.hpa.scaleUp.policy.periodSeconds }}
           {{ else }}
-          stabilizationWindowSeconds: 0
+          stabilizationWindowSeconds: {{ $.Values.keda.hpa.bluegreen.scaleUp.stabilizationWindowSeconds }}
           policies:
-          - type: Percent
-            value: 100
-            periodSeconds: 0
+          - type: {{ $.Values.keda.hpa.bluegreen.scaleUp.policy.type }}
+            value: {{ $.Values.keda.hpa.bluegreen.scaleUp.policy.value }}
+            periodSeconds: {{ $.Values.keda.hpa.bluegreen.scaleUp.policy.periodSeconds }}
           {{ end }}
         scaleDown:
           stabilizationWindowSeconds: {{ $.Values.keda.hpa.scaleDown.stabilizationWindowSeconds }}

--- a/applications/web/templates/scaled-object-blue-green.yaml
+++ b/applications/web/templates/scaled-object-blue-green.yaml
@@ -24,10 +24,10 @@ spec:
       behavior:
         scaleUp:
           {{ if eq $tag $.Values.bluegreen.activeImageTag }}
-          stabilizationWindowSeconds: 0
+          stabilizationWindowSeconds: {{ $.Values.keda.hpa.scaleUp.stabilizationWindowSeconds }}
           policies:
           - type: {{ $.Values.keda.hpa.scaleUp.policy.type }}
-            value: 10
+            value: {{ $.Values.keda.hpa.scaleUp.policy.value }}
             periodSeconds: {{ $.Values.keda.hpa.scaleUp.policy.periodSeconds }}
           {{ else }}
           stabilizationWindowSeconds: 0

--- a/applications/web/templates/scaled-object-blue-green.yaml
+++ b/applications/web/templates/scaled-object-blue-green.yaml
@@ -23,11 +23,19 @@ spec:
     horizontalPodAutoscalerConfig:
       behavior:
         scaleUp:
-          stabilizationWindowSeconds: {{ $.Values.keda.hpa.scaleUp.stabilizationWindowSeconds }}
+          {{ if eq $tag $.Values.bluegreen.activeImageTag }}
+          stabilizationWindowSeconds: 0
           policies:
           - type: {{ $.Values.keda.hpa.scaleUp.policy.type }}
-            value: {{ $.Values.keda.hpa.scaleUp.policy.value }}
+            value: 10
             periodSeconds: {{ $.Values.keda.hpa.scaleUp.policy.periodSeconds }}
+          {{ else }}
+          stabilizationWindowSeconds: 0
+          policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 0
+          {{ end }}
         scaleDown:
           stabilizationWindowSeconds: {{ $.Values.keda.hpa.scaleDown.stabilizationWindowSeconds }}
           policies:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -120,6 +120,13 @@ keda:
         type: Percent
         value: 10
         periodSeconds: 300
+    bluegreen:
+      scaleUp:
+        stabilizationWindowSeconds: 5
+        policy:
+          type: Percent
+          value: 100
+          periodSeconds: 5
     scaleDown:
       stabilizationWindowSeconds: 300
       policy:


### PR DESCRIPTION
Added a check to ensure ScaledObjects in a blue/green deployment always have the same number of replicas running across all versions.