### PR TITLE
KEDA + B/G deployments - replica count lookups

### DIFF
--- a/applications/web/templates/_helpers.tpl
+++ b/applications/web/templates/_helpers.tpl
@@ -32,6 +32,13 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Generate a KEDA ScaledObject's HPA name(only meant for B/G deployments)
+*/}}
+{{- define "docker-template.kedaHpa" -}}
+{{- printf "keda-hpa-%s-%s" .name .tag }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "docker-template.labels" -}}

--- a/applications/web/templates/scaled-object-blue-green.yaml
+++ b/applications/web/templates/scaled-object-blue-green.yaml
@@ -13,8 +13,15 @@ spec:
     name: {{ $fullName }}-{{ $tag }}
   pollingInterval: {{ $.Values.keda.pollingInterval }}
   cooldownPeriod: {{ $.Values.keda.cooldownPeriod }}
+  {{- if eq $tag $.Values.bluegreen.activeImageTag }}
   minReplicaCount: {{ $.Values.keda.minReplicaCount }}
   maxReplicaCount: {{ $.Values.keda.maxReplicaCount }}
+  {{- else }}
+  {{- $kedaHpaData := dict "name" $fullName "tag" $.Values.bluegreen.activeImageTag }}
+  {{- $kedaHpa := include "docker-template.kedaHpa" $kedaHpaData }}
+  minReplicaCount: {{ (lookup "autoscaling/v2" "HorizontalPodAutoscaler" $.Release.Namespace $kedaHpa).status.currentReplicas }}
+  maxReplicaCount: {{ (lookup "autoscaling/v2" "HorizontalPodAutoscaler" $.Release.Namespace $kedaHpa).status.currentReplicas }}
+  {{- end }}
   fallback:
     failureThreshold: {{ $.Values.keda.fallback.failureThreshold }}
     replicas: {{ $.Values.keda.fallback.failureReplicas }}
@@ -23,19 +30,11 @@ spec:
     horizontalPodAutoscalerConfig:
       behavior:
         scaleUp:
-          {{ if eq $tag $.Values.bluegreen.activeImageTag }}
           stabilizationWindowSeconds: {{ $.Values.keda.hpa.scaleUp.stabilizationWindowSeconds }}
           policies:
           - type: {{ $.Values.keda.hpa.scaleUp.policy.type }}
             value: {{ $.Values.keda.hpa.scaleUp.policy.value }}
             periodSeconds: {{ $.Values.keda.hpa.scaleUp.policy.periodSeconds }}
-          {{ else }}
-          stabilizationWindowSeconds: {{ $.Values.keda.hpa.bluegreen.scaleUp.stabilizationWindowSeconds }}
-          policies:
-          - type: {{ $.Values.keda.hpa.bluegreen.scaleUp.policy.type }}
-            value: {{ $.Values.keda.hpa.bluegreen.scaleUp.policy.value }}
-            periodSeconds: {{ $.Values.keda.hpa.bluegreen.scaleUp.policy.periodSeconds }}
-          {{ end }}
         scaleDown:
           stabilizationWindowSeconds: {{ $.Values.keda.hpa.scaleDown.stabilizationWindowSeconds }}
           policies:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -120,13 +120,6 @@ keda:
         type: Percent
         value: 10
         periodSeconds: 300
-    bluegreen:
-      scaleUp:
-        stabilizationWindowSeconds: 5
-        policy:
-          type: Percent
-          value: 100
-          periodSeconds: 5
     scaleDown:
       stabilizationWindowSeconds: 300
       policy:


### PR DESCRIPTION
This PR radically modifies how KEDA `ScaledObjects` behave during a B/G deployment. When a new tag is pushed out, the `web` chart will contain a new `ScaledObject` for the new tag, as before. The difference is that it'll create this `ScaledObject` with min and max replica counts equal to the existing `ScaledObject`'s `HorizontalPodAutoscaler`'s replica count. This will ensure that a new tag deployment will instantiate the same number of replicas as the existing tag. Finally, switching the deployment to the new tag will simply overwrite this "temporary" `ScaledOject`, and ensure the values defined inside the `keda` block are used.