### PR TITLE
Custom TLS

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -57,7 +57,7 @@ spec:
 {{- else }}
   ingressClassName: nginx
 {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if or (.Values.ingress.tls) (.Values.ingress.customTls.enabled) }}
   tls:
     - hosts:
         {{- range $allHosts }}
@@ -66,6 +66,8 @@ spec:
       {{- if not .Values.ingress.useDefaultIngressTLSSecret }}
       {{ if .Values.ingress.wildcard }}
       secretName: wildcard-cert-tls
+      {{ else if .Values.ingress.customTls.enabled }}
+      secretName: {{ .Values.ingress.customTls.customTlsSecret }}
       {{ else }}
       secretName: {{ include "docker-template.fullname" . }}  
       {{ end }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -52,6 +52,9 @@ ingress:
   wildcard: false
   tls: true
   useDefaultIngressTLSSecret: false
+  customTls:
+    enabled: false
+    customTlsSecret:
 
 albIngress:
   enabled: false


### PR DESCRIPTION
This PR adds support for using custom TLS certificates with public Ingress for web apps. A user can create TLS `Secrets` via `kubectl`, and then set a couple of flags on the Helm values for their web app to switch from LetsEncrypt certificates to using the custom certificate.