### PR TITLE
Worker apps - expanded healthchecks

### DIFF
--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -106,6 +106,8 @@ spec:
               - {{ $command | quote }}
               {{- end }}
             periodSeconds: {{ .Values.health.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.startupProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.startupProbe.initialDelaySeconds }}
           {{- end }}
           {{ if .Values.health.readinessProbe.enabled }}
           readinessProbe:
@@ -115,6 +117,19 @@ spec:
               - {{ $command | quote }}
               {{- end }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+          {{- end }}
+          {{ if .Values.health.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command:
+              {{- range $command := trim .Values.health.livenessProbe.command | splitList " " }}
+              - {{ $command | quote }}
+              {{- end }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
           {{- end }}
           resources:
             requests:

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -85,15 +85,24 @@ health:
   command: "ls -l"
   periodSeconds: 5
   failureThreshold: 3
+  livenessProbe:
+    enabled: false
+    command: "ls -l"
+    failureThreshold: 3
+    periodSeconds: 5
+    initialDelaySeconds: 5
   readinessProbe:
     enabled: false
     command: "ls -l"
+    failureThreshold: 3
     periodSeconds: 5
+    initialDelaySeconds: 5
   startupProbe:
     enabled: false
     command: "ls -l"
     failureThreshold: 3
     periodSeconds: 5
+    initialDelaySeconds: 5
 
 pvc:
   enabled: false


### PR DESCRIPTION
This PR makes healthcheck probes - startup, readiness and liveness - consistent for `worker` apps. It also ensures users can configure parameters such as `failureThresholds` and `initialDelaySeconds`.