### PR TITLE
KEDA dynamic triggers

### DIFF
--- a/applications/web/templates/scaled-object-blue-green.yaml
+++ b/applications/web/templates/scaled-object-blue-green.yaml
@@ -51,7 +51,7 @@ spec:
         query: {{ $.Values.keda.trigger.metricQuery }}
         threshold: '{{ $.Values.keda.trigger.metricThreshold }}'
   {{- end }}
-  {{- if len .Values.keda.triggers }}
+  {{- if .Values.keda.triggers }}
   triggers:
   {{- toYaml $.Values.keda.triggers | nindent 4 }}
   {{- end }}

--- a/applications/web/templates/scaled-object.yaml
+++ b/applications/web/templates/scaled-object.yaml
@@ -42,8 +42,8 @@ spec:
         query: {{ .Values.keda.trigger.metricQuery }}
         threshold: '{{ .Values.keda.trigger.metricThreshold }}'
   {{- end }}
-  {{- if len .Values.keda.triggers }}
+  {{- if .Values.keda.triggers }}
   triggers:
-  {{- toYaml .Values.triggers | nindent 4 }}
+  {{- toYaml .Values.keda.triggers | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/applications/worker/templates/scaled-object.yaml
+++ b/applications/worker/templates/scaled-object.yaml
@@ -43,8 +43,8 @@ spec:
         query: {{ .Values.keda.trigger.metricQuery }}
         threshold: '{{ .Values.keda.trigger.metricThreshold }}'
   {{- end }}
-  {{- if len .Values.keda.triggers }}
+  {{- if .Values.keda.triggers }}
   triggers:
-  {{- toYaml .Values.triggers | nindent 4 }}
+  {{- toYaml .Values.keda.triggers | nindent 4 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixed up some typos within the dynamic block where we inject non-Pormetheus triggers into the `ScaledObject` template.