### PR TITLE
ALB fixes

### DIFF
--- a/applications/web/templates/alb-ingress.yaml
+++ b/applications/web/templates/alb-ingress.yaml
@@ -23,6 +23,9 @@ metadata:
     {{- if .Values.albIngress.certificate_arn }}
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.albIngress.certificate_arn }}
     {{- end }}
+    {{- if .Values.albIngress.external_dns }}
+    external-dns.alpha.kubernetes.io/hostname: '{{ join ", " $allHosts }}'
+    {{- end }}
     alb.ingress.kubernetes.io/target-type: {{ .Values.albIngress.target_type }}
     {{- if .Values.albIngress.security_groups }}
     alb.ingress.kubernetes.io/security-groups: {{ .Values.albIngress.security_groups }}

--- a/applications/web/templates/alb-ingress.yaml
+++ b/applications/web/templates/alb-ingress.yaml
@@ -80,7 +80,7 @@ spec:
           {{ else }}
           - path: /*
             {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-            pathType: {{ .pathType | default "ImplementationSpecific" }}
+            pathType: ImplementationSpecific
             {{- end }}
             backend:
             {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -58,6 +58,7 @@ ingress:
 
 albIngress:
   enabled: false
+  external_dns: false
   hosts: []
   certificate_arn:
   custom_paths: []


### PR DESCRIPTION
This PR fixes a lingering bug with support for AWS ALB-based `Ingress` for the `web` chart. It also adds support for using `external-dns` annotations, to dynamically manage DNS entries for `Ingress` objects provisioned for AWS ALBs.