### PR TITLE
support nvidiaGpu in charts

### DIFF
--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -182,6 +182,9 @@ spec:
               memory: {{ .Values.resources.requests.memory }}
             limits:
               memory: {{ .Values.resources.requests.memory }}
+          {{ if .Values.resources.limits }}
+              nvidia.com/gpu: {{ .Values.resources.limits.nvidiaGpu }}
+          {{ end }}
           {{ if or .Values.configMapRefs .Values.secretRefs }}
           envFrom:
           {{ range $configMapName := .Values.configMapRefs }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -141,6 +141,9 @@ spec:
               memory: {{ .Values.resources.requests.memory }}
             limits:
               memory: {{ .Values.resources.requests.memory }}
+          {{ if .Values.resources.limits }}
+              nvidia.com/gpu: {{ .Values.resources.limits.nvidiaGpu }}
+          {{ end }}
           {{ if or .Values.configMapRefs .Values.secretRefs }}
           envFrom:
           {{ range $configMapName := .Values.configMapRefs }}


### PR DESCRIPTION
Support limits which require nvidia gpu to be enabled on a given web or worker application