### PR TITLE
Path types for custom paths

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -81,7 +81,7 @@ spec:
             {{ if gt (len $customPaths) 0 }}
             {{- range $customPaths }}
             - path: {{ .path }}
-              pathType: ImplementationSpecific
+              pathType: {{ .pathType | default "ImplementationSpecific" }}
               backend:
                 service:
                   name: {{ .serviceName }}


### PR DESCRIPTION
Added a template tag for rendering a custom path's type, else setting it to `ImplementationSpecific` by default.