### PR TITLE
https-issuer - updates

### DIFF
--- a/addons/https-issuer/templates/clusterissuer.yaml
+++ b/addons/https-issuer/templates/clusterissuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod

--- a/addons/https-issuer/templates/clusterissuer.yaml
+++ b/addons/https-issuer/templates/clusterissuer.yaml
@@ -1,4 +1,7 @@
+{{- .Capabilities.APIVersions.Has "cert-manager.io/v1"}}
 apiVersion: cert-manager.io/v1
+{{- else}}
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod

--- a/addons/https-issuer/templates/gce-clusterissuer.yaml
+++ b/addons/https-issuer/templates/gce-clusterissuer.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.gce.enabled -}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod-gce

--- a/addons/https-issuer/templates/gce-clusterissuer.yaml
+++ b/addons/https-issuer/templates/gce-clusterissuer.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.gce.enabled -}}
+{{- .Capabilities.APIVersions.Has "cert-manager.io/v1"}}
 apiVersion: cert-manager.io/v1
+{{- else}}
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod-gce

--- a/addons/https-issuer/templates/wildcard_cert.yaml
+++ b/addons/https-issuer/templates/wildcard_cert.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.wildcard.enabled -}}
+{{- .Capabilities.APIVersions.Has "cert-manager.io/v1"}}
 apiVersion: cert-manager.io/v1
+{{- else}}
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: wildcard-cert

--- a/addons/https-issuer/templates/wildcard_cert.yaml
+++ b/addons/https-issuer/templates/wildcard_cert.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.wildcard.enabled -}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: wildcard-cert

--- a/addons/https-issuer/templates/wildcard_issuer.yaml
+++ b/addons/https-issuer/templates/wildcard_issuer.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.wildcard.enabled -}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod-wildcard

--- a/addons/https-issuer/templates/wildcard_issuer.yaml
+++ b/addons/https-issuer/templates/wildcard_issuer.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.wildcard.enabled -}}
+{{- .Capabilities.APIVersions.Has "cert-manager.io/v1"}}
 apiVersion: cert-manager.io/v1
+{{- else}}
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod-wildcard


### PR DESCRIPTION
This PR bumps up API versions used for `Certificates` and `ClusterIssuers`, and adds conditional checks so that:

1. Clusters using `cert-manager` at `v1.5.5` will use `cert-manager.io/v1alpha2`.
2. Clusters using `cert-manager` at `v1.12.3` will use `cert-manager.io/v1`.