### PR TITLE
Porter Agent - Loki storage type

### DIFF
--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -28,6 +28,8 @@ loki:
     auth_enabled: false
     commonConfig:
       replication_factor: 1
+    storage:
+      type: filesystem
   enabled: true
   compactor:
     retention_enabled: true


### PR DESCRIPTION
Switched the Porter agent's Loki sub-chart to use file-system storage by default.