### PR TITLE
Added support for enabling extension mechanisms for DNS 0.

### DIFF
--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -70,6 +70,11 @@ spec:
               containerPort: {{ .containerPort }}
               protocol: TCP
             {{- end }}
+          {{ if $.Values.enableEDNS0 }}
+          dnsConfig:
+            options:
+              - name: edns0
+          {{ end }}
           {{ if $.Values.health.livenessProbe.enabled }}
           livenessProbe:
             httpGet:

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -107,6 +107,11 @@ spec:
               containerPort: {{ .containerPort }}
               protocol: TCP
             {{- end }}
+          {{ if .Values.enableEDNS0 }}
+          dnsConfig:
+            options:
+              - name: edns0
+          {{ end }}
           {{ if .Values.health.livenessProbe.enabled }}
           livenessProbe:
             httpGet:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -215,6 +215,9 @@ datadog:
 # Format: hostAliases: [{ip: <IP>, hostnames: [<HOSTNAME>,..]},..]
 hostAliases: []
 
+# Set this for enabling DNS extensions over TCP
+enableEDNS0: false
+
 nodeSelector: {}
 
 tolerations: []

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -93,6 +93,11 @@ spec:
             - name: http
               containerPort: {{ .Values.container.port }}
               protocol: TCP
+          {{ if .Values.enableEDNS0 }}
+          dnsConfig:
+            options:
+              - name: edns0
+          {{ end }}
           {{ if .Values.readinessProbe }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -118,6 +118,9 @@ cloudsql:
 # Format: hostAliases: [{ip: <IP>, hostnames: [<HOSTNAME>,..]},..]
 hostAliases: []
 
+# Set this for enabling DNS extensions over TCP
+enableEDNS0: false
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
This PR adds support for enabling extension mechanisms over DNS 0, for workloads which run into issues with truncated DNS responses. Setting `enableEDNS0` to `true` results in `Pods` being able to switch to making DNS calls over TCP, if they detect a truncated response to a previous DNS query over standard UDP + the `TC` flag in the original DNS query's response header. 