### PR TITLE
Allow setting the deployment strategy

### DIFF
--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
   selector:
     matchLabels:
       {{- include "docker-template.selectorLabels" . | nindent 6 }}
+  {{- if .Values.strategy }}
+  strategy:
+    type: {{ .Values.strategy }}
+  {{- end }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
We run a number of Kafka consumers. Due to the way Kafka works it needs to use the `Recreate` strategy as the default `RollingUpdate` strategy can result in messages being double processed. This change sets the strategy if the `strategy` key is in the helm values file.