### PR TITLE
[POR-1802] vendor the rds ack chart

### DIFF
--- a/.github/actions/update-ack-chart/action.yml
+++ b/.github/actions/update-ack-chart/action.yml
@@ -1,0 +1,58 @@
+---
+name: 'Update Chart'
+description: 'Allows updating a single chart'
+
+inputs:
+  service:
+    description: 'Name of service to mirror'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: get current version
+      shell: bash
+      id: current
+      run: |
+        if [[ -f "${{ inputs.service }}-chart/Chart.yaml" ]]; then
+          echo "current_version=$(cat ${{ inputs.service }}-chart/Chart.yaml | grep "^version:" | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+        else
+          echo "current_version=" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: mirror latest chart
+      shell: bash
+      run: |
+        RELEASE_VERSION=$(curl -sL "https://api.github.com/repos/aws-controllers-k8s/${{ inputs.service }}-controller/releases/latest" | jq -r '.tag_name | ltrimstr("v")')
+        if [[ "${{ steps.current.outputs.current_version }}" == "$RELEASE_VERSION" ]]; then
+          return
+        fi
+
+        mkdir -p platform
+        rm -rf "platform/${{ inputs.service }}-chart"
+        helm pull "oci://public.ecr.aws/aws-controllers-k8s/${{ inputs.service }}-chart" --version "$RELEASE_VERSION" --untar --untardir platform
+
+    - name: push chart
+      shell: bash
+      run: |
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+
+        if ! git status -s "platform/${{ inputs.service }}-chart" | fgrep ' M '; then
+          return
+        fi
+
+        new_version="$(cat ${{ inputs.service }}-chart/Chart.yaml | grep "^version:" | awk '{print $2}')"
+        branch_name="update-${{ inputs.service }}-chart-from-${{ steps.current.outputs.current_version }}-to-${new_version}"
+        git checkout -b ${{ inputs.service }}-chart
+        git add "platform/${{ inputs.service }}-chart"
+        git commit -m "Update ${{ inputs.service }}-chart to version v${new_version}"
+        git checkout -
+        git push origin "$branch_name"
+        if [[ -n "{{ steps.current.outputs.current_version }}" ]]; then
+          gh pr create --title "Update ${{ inputs.service }}-chart to version v${new_version}" --body "From ${{ steps.current.outputs.current_version }}" --head "$branch_name"
+        else
+          gh pr create --title "Install ${{ inputs.service }}-chart@v${new_version}" --body "New chart" --head "$branch_name"
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-ack-charts.yml
+++ b/.github/workflows/update-ack-charts.yml
@@ -1,0 +1,30 @@
+---
+name: 'Update ACK Charts'
+
+on:
+  schedule:
+    - cron:  '11 5 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-ack-chart:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service:
+          # mysql, postgres
+          - rds
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: azure/setup-helm@v3
+        with:
+          version: 'v3.3.4'
+      - name: Update ACK Service Chart
+        uses: ./.github/actions/update-ack-chart
+        with:
+          service: ${{ matrix.service }}


### PR DESCRIPTION
This is necessary so we don't need to authenticate helm against AWS public, which simplifies the installation process for the ACK chart.

Note that this also automatically vendors the latest version, bumping the repo with a PR as appropriate.