### PR TITLE
chore: upgrade helm for ack chart vendoring

### DIFF
--- a/.github/workflows/update-ack-charts.yml
+++ b/.github/workflows/update-ack-charts.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: azure/setup-helm@v3
         with:
-          version: 'v3.3.4'
+          version: 'v3.12.3'
       - name: Update ACK Service Chart
         uses: ./.github/actions/update-ack-chart
         with:


### PR DESCRIPTION
Older helm doesn't support OCI-backed chart repositories.