### PR TITLE
fix: upgrade checkout and setup-helm to fix warnings in ci

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,10 +7,10 @@ jobs:
     environment: dev
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
         with:
           version: 'v3.3.4'
       - name: Install yq

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -7,10 +7,10 @@ jobs:
     environment: production
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
         with:
           version: 'v3.3.4'
       - name: Install yq

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -7,10 +7,10 @@ jobs:
     environment: staging
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
         with:
           version: 'v3.3.4'
       - name: Install yq


### PR DESCRIPTION
The older versions used outdated nodejs runtimes and older github actions functionality that is no longer supported. Fixing these will silence CI.