### PR TITLE
Ingress<>Certification division

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -3,24 +3,23 @@
 {{- $svcPort := .Values.service.port -}}
 {{- $allHosts := concat .Values.ingress.hosts .Values.ingress.porter_hosts -}}
 {{- $customPaths := .Values.ingress.custom_paths -}}
-{{ range $allHosts }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: '{{ include "docker-template.fullname" $ }}-{{ . | replace "." "-" }}'
+  name: {{ $fullName }}
   labels:
-    {{- include "docker-template.labels" $ | nindent 4 }}
+    {{- include "docker-template.labels" . | nindent 4 }}
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: 50m
     nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
-    {{- if and (gt (len $customPaths) 0) $.Values.ingress.rewriteCustomPathsEnabled }}
+    {{- if and (gt (len $customPaths) 0) .Values.ingress.rewriteCustomPathsEnabled }}
     nginx.ingress.kubernetes.io/rewrite-target: /
     {{- end }}
-    {{- if $.Values.ingress.tls }}
-    {{- if not (hasKey $.Values.ingress.annotations "cert-manager.io/cluster-issuer")}}
-    {{- if $.Values.ingress.wildcard }}
+    {{- if .Values.ingress.tls }}
+    {{- if not (hasKey .Values.ingress.annotations "cert-manager.io/cluster-issuer")}}
+    {{- if .Values.ingress.wildcard }}
     cert-manager.io/cluster-issuer: letsencrypt-prod-wildcard
     {{- else }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
@@ -30,9 +29,9 @@ metadata:
     # provider-agnostic default annotations
     # if value is provided as "null" or null, it is unset
     # adding a fix for scenarios where ingress annotations are inside ingress.annotations.normal
-    {{- if not (hasKey $.Values.ingress.annotations "normal")}} 
-    {{- if gt (len $.Values.ingress.annotations) 0}}
-    {{- range $k, $v := $.Values.ingress.annotations }}
+    {{- if not (hasKey .Values.ingress.annotations "normal")}} 
+    {{- if gt (len .Values.ingress.annotations) 0}}
+    {{- range $k, $v := .Values.ingress.annotations }}
     {{- if $v}}
     {{- if and (not (eq $v "null")) $v}}
     {{ $k }}: {{ $v }}
@@ -41,9 +40,9 @@ metadata:
     {{- end }}
     {{- end }}
     {{- end }}
-    {{- if hasKey $.Values.ingress.annotations "normal"}}
-    {{- if gt (len $.Values.ingress.annotations.normal) 0}}
-    {{- range $k, $v := $.Values.ingress.annotations.normal }}
+    {{- if hasKey .Values.ingress.annotations "normal"}}
+    {{- if gt (len .Values.ingress.annotations.normal) 0}}
+    {{- range $k, $v := .Values.ingress.annotations.normal }}
     {{- if $v}}
     {{- if and (not (eq $v "null")) $v}}
     {{ $k }}: {{ $v }}
@@ -53,14 +52,15 @@ metadata:
     {{- end }}
     {{- end }}
 spec:
-{{- if hasKey $.Values.ingress.annotations "kubernetes.io/ingress.class" }}
-  ingressClassName: {{ index $.Values.ingress.annotations "kubernetes.io/ingress.class" }}
+{{- if hasKey .Values.ingress.annotations "kubernetes.io/ingress.class" }}
+  ingressClassName: {{ index .Values.ingress.annotations "kubernetes.io/ingress.class" }}
 {{- else }}
   ingressClassName: nginx
 {{- end }}
-  {{- if or ($.Values.ingress.tls) ($.Values.ingress.customTls.enabled) }}
+  {{- if or (.Values.ingress.tls) (.Values.ingress.customTls.enabled) }}
+  {{- if .Values.ingress.separateTlsPerCustomDomain}}
   tls:
-    #{{- range $allHosts }}
+    {{- range $allHosts }}
     - hosts:
         - {{ . | quote }}
       {{- if not $.Values.ingress.useDefaultIngressTLSSecret }}
@@ -72,30 +72,46 @@ spec:
       secretName: '{{ include "docker-template.fullname" $ }}-{{ . | replace "." "-" }}'
       {{ end }}
       {{- end }}
-    #{{- end }}
+    {{- end }}
+  {{- else }}
+  tls:
+    - hosts:
+        {{- range $allHosts }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- if not .Values.ingress.useDefaultIngressTLSSecret }}
+      {{ if .Values.ingress.wildcard }}
+      secretName: wildcard-cert-tls
+      {{ else if .Values.ingress.customTls.enabled }}
+      secretName: {{ .Values.ingress.customTls.customTlsSecret }}
+      {{ else }}
+      secretName: {{ include "docker-template.fullname" . }}  
+      {{ end }}
+      {{- end }}
+  {{- end }}
   {{- end }}
   rules:
-    - host: {{ . | quote }}
-      http:
-        paths:
-          {{ if gt (len $customPaths) 0 }}
-          {{- range $customPaths }}
-          - path: {{ .path }}
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: {{ .serviceName }}
-                port:
-                  number: {{ .servicePort }}
-          {{- end }}
-          {{ else }}
-          - pathType: ImplementationSpecific
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-          {{ end }}
----
-{{- end }}
+    {{- range $allHosts }}
+      - host: {{ . | quote }}
+        http:
+          paths:
+            {{ if gt (len $customPaths) 0 }}
+            {{- range $customPaths }}
+            - path: {{ .path }}
+              pathType: ImplementationSpecific
+              backend:
+                service:
+                  name: {{ .serviceName }}
+                  port:
+                    number: {{ .servicePort }}
+            {{- end }}
+            {{ else }}
+            - pathType: ImplementationSpecific
+              backend:
+                service:
+                  name: {{ $fullName }}
+                  port:
+                    number: {{ $svcPort }}
+            {{ end }}
+    {{- end }}
 {{- end }}

--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -3,23 +3,24 @@
 {{- $svcPort := .Values.service.port -}}
 {{- $allHosts := concat .Values.ingress.hosts .Values.ingress.porter_hosts -}}
 {{- $customPaths := .Values.ingress.custom_paths -}}
+{{ range $allHosts }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: '{{ include "docker-template.fullname" $ }}-{{ . | replace "." "-" }}'
   labels:
-    {{- include "docker-template.labels" . | nindent 4 }}
+    {{- include "docker-template.labels" $ | nindent 4 }}
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: 50m
     nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
-    {{- if and (gt (len $customPaths) 0) .Values.ingress.rewriteCustomPathsEnabled }}
+    {{- if and (gt (len $customPaths) 0) $.Values.ingress.rewriteCustomPathsEnabled }}
     nginx.ingress.kubernetes.io/rewrite-target: /
     {{- end }}
-    {{- if .Values.ingress.tls }}
-    {{- if not (hasKey .Values.ingress.annotations "cert-manager.io/cluster-issuer")}}
-    {{- if .Values.ingress.wildcard }}
+    {{- if $.Values.ingress.tls }}
+    {{- if not (hasKey $.Values.ingress.annotations "cert-manager.io/cluster-issuer")}}
+    {{- if $.Values.ingress.wildcard }}
     cert-manager.io/cluster-issuer: letsencrypt-prod-wildcard
     {{- else }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
@@ -29,9 +30,9 @@ metadata:
     # provider-agnostic default annotations
     # if value is provided as "null" or null, it is unset
     # adding a fix for scenarios where ingress annotations are inside ingress.annotations.normal
-    {{- if not (hasKey .Values.ingress.annotations "normal")}} 
-    {{- if gt (len .Values.ingress.annotations) 0}}
-    {{- range $k, $v := .Values.ingress.annotations }}
+    {{- if not (hasKey $.Values.ingress.annotations "normal")}} 
+    {{- if gt (len $.Values.ingress.annotations) 0}}
+    {{- range $k, $v := $.Values.ingress.annotations }}
     {{- if $v}}
     {{- if and (not (eq $v "null")) $v}}
     {{ $k }}: {{ $v }}
@@ -40,9 +41,9 @@ metadata:
     {{- end }}
     {{- end }}
     {{- end }}
-    {{- if hasKey .Values.ingress.annotations "normal"}}
-    {{- if gt (len .Values.ingress.annotations.normal) 0}}
-    {{- range $k, $v := .Values.ingress.annotations.normal }}
+    {{- if hasKey $.Values.ingress.annotations "normal"}}
+    {{- if gt (len $.Values.ingress.annotations.normal) 0}}
+    {{- range $k, $v := $.Values.ingress.annotations.normal }}
     {{- if $v}}
     {{- if and (not (eq $v "null")) $v}}
     {{ $k }}: {{ $v }}
@@ -52,14 +53,14 @@ metadata:
     {{- end }}
     {{- end }}
 spec:
-{{- if hasKey .Values.ingress.annotations "kubernetes.io/ingress.class" }}
-  ingressClassName: {{ index .Values.ingress.annotations "kubernetes.io/ingress.class" }}
+{{- if hasKey $.Values.ingress.annotations "kubernetes.io/ingress.class" }}
+  ingressClassName: {{ index $.Values.ingress.annotations "kubernetes.io/ingress.class" }}
 {{- else }}
   ingressClassName: nginx
 {{- end }}
-  {{- if or (.Values.ingress.tls) (.Values.ingress.customTls.enabled) }}
+  {{- if or ($.Values.ingress.tls) ($.Values.ingress.customTls.enabled) }}
   tls:
-    {{- range $allHosts }}
+    #{{- range $allHosts }}
     - hosts:
         - {{ . | quote }}
       {{- if not $.Values.ingress.useDefaultIngressTLSSecret }}
@@ -71,30 +72,30 @@ spec:
       secretName: '{{ include "docker-template.fullname" $ }}-{{ . | replace "." "-" }}'
       {{ end }}
       {{- end }}
-    {{- end }}
+    #{{- end }}
   {{- end }}
   rules:
-    {{- range $allHosts }}
-      - host: {{ . | quote }}
-        http:
-          paths:
-            {{ if gt (len $customPaths) 0 }}
-            {{- range $customPaths }}
-            - path: {{ .path }}
-              pathType: ImplementationSpecific
-              backend:
-                service:
-                  name: {{ .serviceName }}
-                  port:
-                    number: {{ .servicePort }}
-            {{- end }}
-            {{ else }}
-            - pathType: ImplementationSpecific
-              backend:
-                service:
-                  name: {{ $fullName }}
-                  port:
-                    number: {{ $svcPort }}
-            {{ end }}
-    {{- end }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          {{ if gt (len $customPaths) 0 }}
+          {{- range $customPaths }}
+          - path: {{ .path }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ .serviceName }}
+                port:
+                  number: {{ .servicePort }}
+          {{- end }}
+          {{ else }}
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{ end }}
+---
+{{- end }}
 {{- end }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -52,6 +52,7 @@ ingress:
   wildcard: false
   tls: true
   useDefaultIngressTLSSecret: false
+  separateTlsPerCustomDomain: true
   customTls:
     enabled: false
     customTlsSecret:


### PR DESCRIPTION
This PR introduces a new parameter - `ingress.separateTlsPerCustomDomain`, which is set to `true` by default. When set to `true`, the chart follows normal procedure where a single `Ingress` is created with multiple `Certificates`, one for each host. However, when this flag is set to `false`, then the chart falls back to older behaviour, where all hosts are included in one `Ingress` and a single `Certificate`. This is useful for scenarios where customers may have more than 30 domains, which would mean they'd get rate-limited by LetsEncrypt.