### PR TITLE
add env groups to the job hook used for predeploys

### DIFF
--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -86,6 +86,15 @@ data:
             {{- end }}
             {{- end }}
             {{- end }}
+            envFrom:
+            {{ range $configMapName := .Values.configMapRefs }}
+              - configMapRef:
+                  name: {{ $configMapName }}
+            {{ end }}
+            {{ range $secretName := .Values.secretRefs }}
+              - secretRef:
+                  name: {{ $secretName }}
+            {{ end }}
             env:
             {{- range $key, $val := .Values.container.env.normal }}
             - name: {{ $key }}


### PR DESCRIPTION
The jobs generated from the config map (i.e. manual jobs and the initial jobs created at deployment) currently don't get the env groups piped into them.  We need this added so that predeploy jobs have access to environment variables from env groups.