### PR TITLE
[POR-1804] add helm chart for creating a postgresql instance

### DIFF
--- a/addons/rds-postgresql/Chart.yaml
+++ b/addons/rds-postgresql/Chart.yaml
@@ -1,0 +1,23 @@
+annotations:
+  category: Database
+apiVersion: v2
+appVersion: "15.4"
+description: A object-relational database management system (ORDBMS) with an emphasis on extensibility, standards-compliance and high-availability.
+home: https://github.com/porter-dev/porter-charts/tree/master/addons/rds-postgresql
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+keywords:
+  - postgresql
+  - postgres
+  - db
+  - database
+  - sql
+  - replication
+  - cluster
+  - rds
+  - DATA_STORE
+  - DATA_BASE
+maintainers:
+  - name: Porter Technologies, Inc.
+    email: support@porter.run
+name: rds-postgresql
+version: 0.1.0

--- a/addons/rds-postgresql/README.md
+++ b/addons/rds-postgresql/README.md
@@ -1,0 +1,1 @@
+# RDS PostgreSQL

--- a/addons/rds-postgresql/form.yaml
+++ b/addons/rds-postgresql/form.yaml
@@ -30,3 +30,9 @@ tabs:
     - type: string-input
       label: Cluster Subnet IDs (comma-delimited)
       variable: config.subnetsIDs
+    - type: string-input
+      label: VPC ID
+      variable: config.vpcID
+    - type: string-input
+      label: Engine Version
+      variable: config.engineVersion

--- a/addons/rds-postgresql/form.yaml
+++ b/addons/rds-postgresql/form.yaml
@@ -27,3 +27,6 @@ tabs:
     - type: string-input
       label: AWS Region
       variable: config.awsRegion
+    - type: string-input
+      label: Cluster Subnet IDs (comma-delimited)
+      variable: config.subnetsIDs

--- a/addons/rds-postgresql/form.yaml
+++ b/addons/rds-postgresql/form.yaml
@@ -1,0 +1,29 @@
+name: RDS PostgreSQL
+tabs:
+- name: main
+  label: Main Settings
+  sections:
+  - name: main_section
+    contents:
+    - type: heading
+      label: RDS Resources
+    - type: subtitle
+      label: Configure resources assigned to this RDS PostgreSQL instance.
+    - type: string-input
+      label: Database 
+      variable: config.name
+    - type: string-input
+      label: Username
+      variable: config.masterUsername
+    - type: string-input
+      label: Password
+      variable: config.masterUserPassword
+    - type: string-input
+      label: Instance Class
+      variable: config.instanceClass
+    - type: string-input
+      label: Storage Capacity (GB)
+      variable: config.allocatedStorage
+    - type: string-input
+      label: AWS Region
+      variable: config.awsRegion

--- a/addons/rds-postgresql/templates/db_instance.yaml
+++ b/addons/rds-postgresql/templates/db_instance.yaml
@@ -20,3 +20,6 @@ spec:
     namespace: porter-env-group
     name: {{ .Values.config.name }}.1
     key: DB_PASS
+  tags:
+    - key: "porter.run/managed"
+      value: "true"

--- a/addons/rds-postgresql/templates/db_instance.yaml
+++ b/addons/rds-postgresql/templates/db_instance.yaml
@@ -38,3 +38,6 @@ spec:
   tags:
     - key: "porter.run/managed"
       value: "true"
+  vpcSecurityGroupRefs:
+    - from:
+        name: {{ .Values.config.name }}-postgresql

--- a/addons/rds-postgresql/templates/db_instance.yaml
+++ b/addons/rds-postgresql/templates/db_instance.yaml
@@ -13,6 +13,9 @@ spec:
   dbSubnetGroupRef:
     from:
       name: {{ .Values.config.name }}
+  dbParameterGroupRef:
+    from:
+      name: {{ .Values.config.name }}
   engine: postgres
   engineVersion: "{{ .Values.config.engineVersion }}"
   masterUsername: "{{ .Values.config.masterUsername }}"

--- a/addons/rds-postgresql/templates/db_instance.yaml
+++ b/addons/rds-postgresql/templates/db_instance.yaml
@@ -10,6 +10,7 @@ spec:
   allocatedStorage: {{ .Values.config.allocatedStorage }}
   autoMinorVersionUpgrade: true
   backupRetentionPeriod: 14
+  caCertificateIdentifier: rds-ca-rsa2048-g1
   copyTagsToSnapshot: true
   dbInstanceClass: {{ .Values.config.instanceClass }}
   dbInstanceIdentifier: {{ .Values.config.name }}

--- a/addons/rds-postgresql/templates/db_instance.yaml
+++ b/addons/rds-postgresql/templates/db_instance.yaml
@@ -10,6 +10,9 @@ spec:
   allocatedStorage: {{ .Values.config.allocatedStorage }}
   dbInstanceClass: {{ .Values.config.instanceClass }}
   dbInstanceIdentifier: {{ .Values.config.name }}
+  dbSubnetGroupRef:
+    from:
+      name: {{ .Values.config.name }}
   engine: postgres
   engineVersion: "{{ .Values.config.engineVersion }}"
   masterUsername: "{{ .Values.config.masterUsername }}"

--- a/addons/rds-postgresql/templates/db_instance.yaml
+++ b/addons/rds-postgresql/templates/db_instance.yaml
@@ -8,6 +8,9 @@ metadata:
     services.k8s.aws/region: {{ .Values.config.awsRegion }}
 spec:
   allocatedStorage: {{ .Values.config.allocatedStorage }}
+  autoMinorVersionUpgrade: true
+  backupRetentionPeriod: 14
+  copyTagsToSnapshot: true
   dbInstanceClass: {{ .Values.config.instanceClass }}
   dbInstanceIdentifier: {{ .Values.config.name }}
   dbSubnetGroupRef:
@@ -16,6 +19,9 @@ spec:
   dbParameterGroupRef:
     from:
       name: {{ .Values.config.name }}
+  enableCloudwatchLogsExports:
+    - postgresql
+    - upgrade
   engine: postgres
   engineVersion: "{{ .Values.config.engineVersion }}"
   masterUsername: "{{ .Values.config.masterUsername }}"
@@ -24,6 +30,10 @@ spec:
     name: {{ .Values.config.name }}.1
     key: DB_PASS
   multiAZ: {{ .Values.config.multiAZ }}
+  performanceInsightsEnabled: true
+  performanceInsightsRetentionPeriod: 7
+  storageEncrypted: true
+  storageType: gp3
   tags:
     - key: "porter.run/managed"
       value: "true"

--- a/addons/rds-postgresql/templates/db_instance.yaml
+++ b/addons/rds-postgresql/templates/db_instance.yaml
@@ -13,6 +13,7 @@ spec:
   copyTagsToSnapshot: true
   dbInstanceClass: {{ .Values.config.instanceClass }}
   dbInstanceIdentifier: {{ .Values.config.name }}
+  dbName: {{ .Values.config.name | lower | nospace | replace "-" " " }}
   dbSubnetGroupRef:
     from:
       name: {{ .Values.config.name }}

--- a/addons/rds-postgresql/templates/db_instance.yaml
+++ b/addons/rds-postgresql/templates/db_instance.yaml
@@ -23,6 +23,7 @@ spec:
     namespace: porter-env-group
     name: {{ .Values.config.name }}.1
     key: DB_PASS
+  multiAZ: {{ .Values.config.multiAZ }}
   tags:
     - key: "porter.run/managed"
       value: "true"

--- a/addons/rds-postgresql/templates/db_instance.yaml
+++ b/addons/rds-postgresql/templates/db_instance.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBInstance
+metadata:
+  name: {{ .Values.config.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    services.k8s.aws/region: {{ .Values.config.awsRegion }}
+spec:
+  allocatedStorage: {{ .Values.config.allocatedStorage }}
+  dbInstanceClass: {{ .Values.config.instanceClass }}
+  dbInstanceIdentifier: {{ .Values.config.name }}
+  engine: postgres
+  engineVersion: "{{ .Values.config.engineVersion }}"
+  masterUsername: "{{ .Values.config.masterUsername }}"
+  masterUserPassword:
+    namespace: porter-env-group
+    name: {{ .Values.config.name }}.1
+    key: DB_PASS

--- a/addons/rds-postgresql/templates/db_instance.yaml
+++ b/addons/rds-postgresql/templates/db_instance.yaml
@@ -14,7 +14,7 @@ spec:
   copyTagsToSnapshot: true
   dbInstanceClass: {{ .Values.config.instanceClass }}
   dbInstanceIdentifier: {{ .Values.config.name }}
-  dbName: {{ .Values.config.name | lower | nospace | replace "-" " " }}
+  dbName: {{ .Values.config.name | snakecase | nospace }}
   dbSubnetGroupRef:
     from:
       name: {{ .Values.config.name }}

--- a/addons/rds-postgresql/templates/parameter_group.yaml
+++ b/addons/rds-postgresql/templates/parameter_group.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: rds.services.k8s.aws/v1alpha1
-kind: DBClusterParameterGroup
+kind: DBParameterGroup
 metadata:
   name: {{ .Values.config.name }}
   namespace: {{ .Release.Namespace }}

--- a/addons/rds-postgresql/templates/parameter_group.yaml
+++ b/addons/rds-postgresql/templates/parameter_group.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBClusterParameterGroup
+metadata:
+  name: {{ .Values.config.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    services.k8s.aws/region: {{ .Values.config.awsRegion }}
+spec:
+  description: "Parameter group for {{ .Values.config.name }}"
+  family: postgres{{ .Values.config.engineMajorVersion }}
+  name: {{ .Values.config.name }}
+  tags:
+    - key: "porter.run/managed"
+      value: "true"

--- a/addons/rds-postgresql/templates/parameter_group.yaml
+++ b/addons/rds-postgresql/templates/parameter_group.yaml
@@ -8,7 +8,7 @@ metadata:
     services.k8s.aws/region: {{ .Values.config.awsRegion }}
 spec:
   description: "Parameter group for {{ .Values.config.name }}"
-  family: postgres{{ .Values.config.engineMajorVersion }}
+  family: postgres{{ (semver (toString .Values.config.engineVersion)).Major }}
   name: {{ .Values.config.name }}
   tags:
     - key: "porter.run/managed"

--- a/addons/rds-postgresql/templates/secret.yaml
+++ b/addons/rds-postgresql/templates/secret.yaml
@@ -19,3 +19,6 @@ metadata:
   labels:
     porter.run/environment-group-name: {{ .Values.config.name }}.1
     porter.run/environment-group-version: "1"
+data:
+  DB_PORT: "5432"
+  DB_USER: {{ .Values.config.masterUsername }}

--- a/addons/rds-postgresql/templates/secret.yaml
+++ b/addons/rds-postgresql/templates/secret.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Values.config.name }}.1
+  namespace: porter-env-group
+  labels:
+    porter.run/environment-group-name: {{ .Values.config.name }}.1
+    porter.run/environment-group-version: "1"
+data:
+  DB_PASS: "{{ .Values.config.masterUserPassword | b64enc }}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.config.name }}.1
+  namespace: porter-env-group
+  labels:
+    porter.run/environment-group-name: {{ .Values.config.name }}.1
+    porter.run/environment-group-version: "1"

--- a/addons/rds-postgresql/templates/secret.yaml
+++ b/addons/rds-postgresql/templates/secret.yaml
@@ -8,6 +8,8 @@ metadata:
   labels:
     porter.run/environment-group-name: {{ .Values.config.name }}.1
     porter.run/environment-group-version: "1"
+    porter.run/environment-group-datastore: {{ .Values.config.name }}
+    porter.run/environment-group-datastore-type: postgresql
 data:
   DB_PASS: "{{ .Values.config.masterUserPassword | b64enc }}"
 ---
@@ -19,6 +21,8 @@ metadata:
   labels:
     porter.run/environment-group-name: {{ .Values.config.name }}.1
     porter.run/environment-group-version: "1"
+    porter.run/environment-group-datastore: {{ .Values.config.name }}
+    porter.run/environment-group-datastore-type: postgresql
 data:
   DB_PORT: "5432"
   DB_USER: {{ .Values.config.masterUsername }}

--- a/addons/rds-postgresql/templates/secret.yaml
+++ b/addons/rds-postgresql/templates/secret.yaml
@@ -22,3 +22,21 @@ metadata:
 data:
   DB_PORT: "5432"
   DB_USER: {{ .Values.config.masterUsername }}
+---
+apiVersion: services.k8s.aws/v1alpha1
+kind: FieldExport
+metadata:
+  name: {{ .Values.config.name }}-host
+  namespace: {{ .Release.Namespace }}
+spec:
+  to:
+    name: {{ .Values.config.name }}.1
+    namespace: porter-env-group
+    key: DB_HOST
+    kind: configmap
+  from:
+    path: ".status.endpoint.address"
+    resource:
+      group: rds.services.k8s.aws
+      kind: DBInstance
+      name: {{ .Values.config.name }}

--- a/addons/rds-postgresql/templates/security_group.yaml
+++ b/addons/rds-postgresql/templates/security_group.yaml
@@ -13,7 +13,7 @@ spec:
   ingressRules:
   - ipProtocol: tcp
     ipRanges:
-    - cidrIP: "{{ .Values.config.vpcID }}"
+    - cidrIP: "0.0.0.0/0"
     fromPort: 5432
     toPort: 5432
   tags:

--- a/addons/rds-postgresql/templates/security_group.yaml
+++ b/addons/rds-postgresql/templates/security_group.yaml
@@ -15,7 +15,7 @@ spec:
     ipRanges:
     - cidrIP: "{{ .Values.config.vpcID }}"
     fromPort: 5432
-    toPort: 5432Z
+    toPort: 5432
   tags:
     - key: "porter.run/managed"
       value: "true"

--- a/addons/rds-postgresql/templates/security_group.yaml
+++ b/addons/rds-postgresql/templates/security_group.yaml
@@ -17,5 +17,7 @@ spec:
     fromPort: 5432
     toPort: 5432
   tags:
+    - key: "Name"
+      value: "{{ .Values.config.name }}-postgresql"
     - key: "porter.run/managed"
       value: "true"

--- a/addons/rds-postgresql/templates/security_group.yaml
+++ b/addons/rds-postgresql/templates/security_group.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: {{ .Values.config.name }}-postgresql
+  namespace: {{ .Release.Namespace }}
+spec:
+  description: SecurityGroup
+  name: {{ .Values.config.name }}-postgresql
+  vpcID: {{ .Values.config.vpcID }}
+  ingressRules:
+  - ipProtocol: tcp
+    ipRanges:
+    - cidrIP: "{{ .Values.config.vpcID }}"
+    fromPort: 5432
+    toPort: 5432Z
+  tags:
+    - key: "porter.run/managed"
+      value: "true"

--- a/addons/rds-postgresql/templates/security_group.yaml
+++ b/addons/rds-postgresql/templates/security_group.yaml
@@ -4,6 +4,8 @@ kind: SecurityGroup
 metadata:
   name: {{ .Values.config.name }}-postgresql
   namespace: {{ .Release.Namespace }}
+  annotations:
+    services.k8s.aws/region: {{ .Values.config.awsRegion }}
 spec:
   description: SecurityGroup
   name: {{ .Values.config.name }}-postgresql

--- a/addons/rds-postgresql/templates/subnets.yaml
+++ b/addons/rds-postgresql/templates/subnets.yaml
@@ -4,6 +4,8 @@ kind: DBSubnetGroup
 metadata:
   name: {{ .Values.config.name }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    services.k8s.aws/region: {{ .Values.config.awsRegion }}
 spec:
   name: {{ .Values.config.name }}
   description: "{{ .Values.config.name }} Subnet Group"

--- a/addons/rds-postgresql/templates/subnets.yaml
+++ b/addons/rds-postgresql/templates/subnets.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBSubnetGroup
+metadata:
+  name: {{ .Values.config.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  name: {{ .Values.config.name }}
+  description: "{{ .Values.config.name }} Subnet Group"
+{{- if .Values.config.subnetsIDs }}
+  imagePullSecrets:
+  {{- range .Values.config.subnetsIDs }}
+    - {{ toYaml . }}
+  {{- end}}
+{{- end }}

--- a/addons/rds-postgresql/templates/subnets.yaml
+++ b/addons/rds-postgresql/templates/subnets.yaml
@@ -13,3 +13,6 @@ spec:
     - {{ toYaml . }}
   {{- end}}
 {{- end }}
+  tags:
+    - key: "porter.run/managed"
+      value: "true"

--- a/addons/rds-postgresql/templates/subnets.yaml
+++ b/addons/rds-postgresql/templates/subnets.yaml
@@ -8,7 +8,7 @@ spec:
   name: {{ .Values.config.name }}
   description: "{{ .Values.config.name }} Subnet Group"
 {{- if .Values.config.subnetsIDs }}
-  imagePullSecrets:
+  subnetIDs:
   {{- range .Values.config.subnetsIDs }}
     - {{ toYaml . }}
   {{- end}}

--- a/addons/rds-postgresql/values.yaml
+++ b/addons/rds-postgresql/values.yaml
@@ -1,7 +1,6 @@
 config:
   allocatedStorage: 30
   awsRegion: ""
-  engineMajorVersion: 15
   engineVersion: 15.4
   instanceClass: db.t4g.small
   masterUsername: root

--- a/addons/rds-postgresql/values.yaml
+++ b/addons/rds-postgresql/values.yaml
@@ -5,5 +5,6 @@ config:
   instanceClass: db.t4g.small
   allocatedStorage: 30
   awsRegion: ""
+  engineMajorVersion: 15
   engineVersion: 15.4
   subnetsIDs: []

--- a/addons/rds-postgresql/values.yaml
+++ b/addons/rds-postgresql/values.yaml
@@ -9,3 +9,4 @@ config:
   multiAZ: true
   name: ""
   subnetsIDs: []
+  vpcID: ""

--- a/addons/rds-postgresql/values.yaml
+++ b/addons/rds-postgresql/values.yaml
@@ -5,5 +5,5 @@ config:
   instanceClass: db.t4g.small
   allocatedStorage: 30
   awsRegion: ""
-  engineVersion: 15.4-R2
+  engineVersion: 15.4
   subnetsIDs: []

--- a/addons/rds-postgresql/values.yaml
+++ b/addons/rds-postgresql/values.yaml
@@ -1,0 +1,8 @@
+config:
+  name: ""
+  masterUsername: root
+  masterUserPassword: ""
+  instanceClass: db.t4g.small
+  allocatedStorage: 30
+  awsRegion: ""
+  engineVersion: 15.4-R2

--- a/addons/rds-postgresql/values.yaml
+++ b/addons/rds-postgresql/values.yaml
@@ -6,3 +6,4 @@ config:
   allocatedStorage: 30
   awsRegion: ""
   engineVersion: 15.4-R2
+  subnetsIDs: []

--- a/addons/rds-postgresql/values.yaml
+++ b/addons/rds-postgresql/values.yaml
@@ -6,5 +6,6 @@ config:
   instanceClass: db.t4g.small
   masterUsername: root
   masterUserPassword: ""
+  multiAZ: true
   name: ""
   subnetsIDs: []

--- a/addons/rds-postgresql/values.yaml
+++ b/addons/rds-postgresql/values.yaml
@@ -1,10 +1,10 @@
 config:
-  name: ""
-  masterUsername: root
-  masterUserPassword: ""
-  instanceClass: db.t4g.small
   allocatedStorage: 30
   awsRegion: ""
   engineMajorVersion: 15
   engineVersion: 15.4
+  instanceClass: db.t4g.small
+  masterUsername: root
+  masterUserPassword: ""
+  name: ""
   subnetsIDs: []


### PR DESCRIPTION
This pull request implements the `rds-postgresql` wrapper chart that allows creating a custom rds instance via helm. It depends on the code in porter-dev/cluster-control-plane#290 to ensure the CRDs are defined for interacting with AWS via ACK.

A sample helm-values yaml file is as follows:

```yaml
# replace your region, subnets, and vpc as appropriate
config:
  name: "test"
  masterUsername: root
  masterUserPassword: "testpassword"
  instanceClass: db.t4g.small
  allocatedStorage: 30
  awsRegion: "us-east-1"
  engineVersion: 15.4
  subnetsIDs:
    - subnet-0162adf3d32d664af
    - subnet-09060888b48664b28
    - subnet-0adb8b165f10f2db9
  vpcID: vpc-09cd0772d1b4ecd50
```

To run:

```
porter helm -- install -f addons/rds-postgresql/test-values.yaml --namespace ack-system test addons/rds-postgresql
```