### PR TITLE
[POR-1892] add the ack ec2-chart

### DIFF
--- a/.github/workflows/update-ack-charts.yml
+++ b/.github/workflows/update-ack-charts.yml
@@ -16,6 +16,8 @@ jobs:
     strategy:
       matrix:
         service:
+          # security groups
+          - ec2
           # mysql, postgres
           - rds
           # memcached, redis


### PR DESCRIPTION
This is for managing ec2 security groups, which are used by all ACK-managed AWS datastores. No other functionality can/should be used from this chart.