### PR TITLE
Add ack-chart to list of synced remote helm charts

### DIFF
--- a/.github/workflows/sync-remote-helm-charts.yaml
+++ b/.github/workflows/sync-remote-helm-charts.yaml
@@ -13,6 +13,10 @@ jobs:
             remote_repository: eks-charts
             remote_directory: stable/aws-cloudwatch-metrics
             target_directory: addons/aws-cloudwatch-metrics
+          - remote_owner: aws-controllers-k8s
+            remote_repository: ack-chart
+            remote_directory: .
+            target_directory: addons/ack-chart
 
     permissions:
       contents: write


### PR DESCRIPTION
I think the `.` should be fine for the `remote_directory`, but if not, I'll see about fixing the underlying action to add support for setting the repo root as the synced chart.