### PR TITLE
Separate out the vpc subnet config

### DIFF
--- a/addons/rds-postgresql/form.yaml
+++ b/addons/rds-postgresql/form.yaml
@@ -29,10 +29,10 @@ tabs:
       variable: config.awsRegion
     - type: string-input
       label: Cluster Subnet IDs (comma-delimited)
-      variable: config.subnetsIDs
+      variable: vpcConfig.subnetsIDs
     - type: string-input
       label: VPC ID
-      variable: config.vpcID
+      variable: vpcConfig.vpcID
     - type: string-input
       label: Engine Version
       variable: config.engineVersion

--- a/addons/rds-postgresql/templates/subnets.yaml
+++ b/addons/rds-postgresql/templates/subnets.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   name: {{ .Values.config.name }}
   description: "{{ .Values.config.name }} Subnet Group"
-{{- if .Values.config.subnetsIDs }}
+{{- if .Values.vpcConfig.subnetsIDs }}
   subnetIDs:
-  {{- range .Values.config.subnetsIDs }}
+  {{- range .Values.vpcConfig.subnetsIDs }}
     - {{ toYaml . }}
   {{- end}}
 {{- end }}

--- a/addons/rds-postgresql/values.yaml
+++ b/addons/rds-postgresql/values.yaml
@@ -7,5 +7,7 @@ config:
   masterUserPassword: ""
   multiAZ: true
   name: ""
+
+vpcConfig:
   subnetsIDs: []
   vpcID: ""


### PR DESCRIPTION
This change is so that we don't accidentally shadow any config in any other charts when injecting vpc info.