### PR TITLE
refactor: move awsRegion to vpcConfig section

### DIFF
--- a/addons/rds-postgresql/form.yaml
+++ b/addons/rds-postgresql/form.yaml
@@ -26,7 +26,7 @@ tabs:
       variable: config.allocatedStorage
     - type: string-input
       label: AWS Region
-      variable: config.awsRegion
+      variable: vpcConfig.awsRegion
     - type: string-input
       label: Cluster Subnet IDs (comma-delimited)
       variable: vpcConfig.subnetsIDs

--- a/addons/rds-postgresql/templates/db_instance.yaml
+++ b/addons/rds-postgresql/templates/db_instance.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.config.name }}
   namespace: {{ .Release.Namespace }}
   annotations:
-    services.k8s.aws/region: {{ .Values.config.awsRegion }}
+    services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
 spec:
   allocatedStorage: {{ .Values.config.allocatedStorage }}
   autoMinorVersionUpgrade: true

--- a/addons/rds-postgresql/templates/parameter_group.yaml
+++ b/addons/rds-postgresql/templates/parameter_group.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.config.name }}
   namespace: {{ .Release.Namespace }}
   annotations:
-    services.k8s.aws/region: {{ .Values.config.awsRegion }}
+    services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
 spec:
   description: "Parameter group for {{ .Values.config.name }}"
   family: postgres{{ (semver (toString .Values.config.engineVersion)).Major }}

--- a/addons/rds-postgresql/templates/security_group.yaml
+++ b/addons/rds-postgresql/templates/security_group.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.config.name }}-postgresql
   namespace: {{ .Release.Namespace }}
   annotations:
-    services.k8s.aws/region: {{ .Values.config.awsRegion }}
+    services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
 spec:
   description: SecurityGroup
   name: {{ .Values.config.name }}-postgresql

--- a/addons/rds-postgresql/templates/subnets.yaml
+++ b/addons/rds-postgresql/templates/subnets.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.config.name }}
   namespace: {{ .Release.Namespace }}
   annotations:
-    services.k8s.aws/region: {{ .Values.config.awsRegion }}
+    services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
 spec:
   name: {{ .Values.config.name }}
   description: "{{ .Values.config.name }} Subnet Group"

--- a/addons/rds-postgresql/values.yaml
+++ b/addons/rds-postgresql/values.yaml
@@ -1,6 +1,5 @@
 config:
   allocatedStorage: 30
-  awsRegion: ""
   engineVersion: 15.4
   instanceClass: db.t4g.small
   masterUsername: root
@@ -9,5 +8,6 @@ config:
   name: ""
 
 vpcConfig:
+  awsRegion: ""
   subnetsIDs: []
   vpcID: ""


### PR DESCRIPTION
This aligns it with everything else related to how a resource is placed in AWS.