### PR TITLE
fix: fail on errors in shell scripts

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 versionJQ='
 def handle: .[] | [.version] | sort_by( split(".") | map(tonumber) ) | last ;


### PR DESCRIPTION
Without this, helm chart publishing silently ignores failures in CI, giving us a false sense of things actually working.