### PR TITLE
fix: build dependencies to avoid packaging issues

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -81,6 +81,7 @@ package_helm() {
 
   yq e '.version = "'"$new_version"'"' -i "$chart_path"
 
+  helm dependency build "$helm_dir"
   helm package "$helm_dir"
 }
 


### PR DESCRIPTION
Otherwise the ack-chart gets a lovely error like this:

```
Error: found in Chart.yaml, but missing in charts/ directory: apigatewayv2-chart, applicationautoscaling-chart, cloudtrail-chart, dynamodb-chart, ec2-chart, ecr-chart, eks-chart, emrcontainers-chart, eventbridge-chart, iam-chart, kms-chart, lambda-chart, memorydb-chart, pipes-chart, prometheusservice-chart, rds-chart, s3-chart, sagemaker-chart, sfn-chart, sns-chart, sqs-chart
```