### PR TITLE
fix: use correct variable for ack-chart name

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -81,7 +81,8 @@ package_helm() {
 
   yq e '.version = "'"$new_version"'"' -i "$chart_path"
 
-  if [[ "$helm_dir" == "ack-chart" ]]; then
+  if [[ "$chart_name" == "ack-chart" ]]; then
+    continue
     yq -i '.dependencies[].repository = env(CHARTMUSEUM_URL)' ack-chart/Chart.yaml
     helm dependency update "$helm_dir"
   fi


### PR DESCRIPTION
Also skip over it for now so we can publish the rest of the ack charts.