### PR TITLE
fix: set max_wal_senders to 20 in order to properly support multi-az …

### DIFF
--- a/addons/rds-postgresql/templates/parameter_group.yaml
+++ b/addons/rds-postgresql/templates/parameter_group.yaml
@@ -7,9 +7,11 @@ metadata:
   annotations:
     services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
 spec:
+  name: {{ .Values.config.name }}
   description: "Parameter group for {{ .Values.config.name }}"
   family: postgres{{ (semver (toString .Values.config.engineVersion)).Major }}
-  name: {{ .Values.config.name }}
+  parameterOverrides:
+    max_wal_senders: "20"
   tags:
     - key: "porter.run/managed"
       value: "true"


### PR DESCRIPTION
…clusters

Without this minimal change, the dbparametergroup CRD will have a value of 10, which will be reconciled every so often, and then reverted by RDS because its not valid for multi-az instances, causing constant churn on the parameter group.