### PR TITLE
feat: configure enhanced monitoring by setting the monitoring interval

### DIFF
--- a/addons/rds-postgresql/templates/db_instance.yaml
+++ b/addons/rds-postgresql/templates/db_instance.yaml
@@ -31,6 +31,7 @@ spec:
     namespace: porter-env-group
     name: {{ .Values.config.name }}.1
     key: DB_PASS
+  monitoringInterval: 60
   multiAZ: {{ .Values.config.multiAZ }}
   performanceInsightsEnabled: true
   performanceInsightsRetentionPeriod: 7


### PR DESCRIPTION
The default value is 0, disabling enhanced monitoring. Enabling allows for collection of extra performance metrics in cloudwatch. It's slightly more expensive but necessary for anyone running a production cluster at scale..

We can allow for non-enhanced nodes in the future via helm value, but I think enabling this by default is desirable for users.