### PR TITLE
feat: add support for aurora db with postgresql

### DIFF
--- a/addons/rds-postgresql-aurora/Chart.yaml
+++ b/addons/rds-postgresql-aurora/Chart.yaml
@@ -1,0 +1,24 @@
+annotations:
+  category: Database
+apiVersion: v2
+appVersion: "15.4"
+description: Amazon Aurora is a relational database management system (RDBMS) built for the cloud with full MySQL and PostgreSQL compatibility. 
+home: https://github.com/porter-dev/porter-charts/tree/master/addons/rds-postgresql-aurora
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+keywords:
+  - aurora
+  - postgresql-aurora
+  - postgres-aurora
+  - db
+  - database
+  - sql
+  - replication
+  - cluster
+  - rds
+  - DATA_STORE
+  - DATA_BASE
+maintainers:
+  - name: Porter Technologies, Inc.
+    email: support@porter.run
+name: rds-postgresql-aurora
+version: 0.0.0

--- a/addons/rds-postgresql-aurora/README.md
+++ b/addons/rds-postgresql-aurora/README.md
@@ -1,0 +1,1 @@
+# RDS PostgreSQL Aurora

--- a/addons/rds-postgresql-aurora/form.yaml
+++ b/addons/rds-postgresql-aurora/form.yaml
@@ -1,0 +1,41 @@
+name: RDS PostgreSQL Aurora
+tabs:
+- name: main
+  label: Main Settings
+  sections:
+  - name: main_section
+    contents:
+    - type: heading
+      label: RDS Resources
+    - type: subtitle
+      label: Configure resources assigned to this RDS PostgreSQL Aurora instance.
+    - type: string-input
+      label: Database 
+      variable: config.name
+    - type: string-input
+      label: Username
+      variable: config.masterUsername
+    - type: string-input
+      label: Password
+      variable: config.masterUserPassword
+    - type: string-input
+      label: Instance Class
+      variable: config.instanceClass
+    - type: string-input
+      label: Storage Capacity (GB)
+      variable: config.allocatedStorage
+    - type: string-input
+      label: Instance Count
+      variable: config.instanceCount
+    - type: string-input
+      label: AWS Region
+      variable: vpcConfig.awsRegion
+    - type: string-input
+      label: Cluster Subnet IDs (comma-delimited)
+      variable: vpcConfig.subnetIDs
+    - type: string-input
+      label: VPC ID
+      variable: vpcConfig.vpcID
+    - type: string-input
+      label: Engine Version
+      variable: config.engineVersion

--- a/addons/rds-postgresql-aurora/templates/_helpers.tpl
+++ b/addons/rds-postgresql-aurora/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{- define "generate_static_password" -}}
+{{- /* Create "tmp_vars" dict inside ".Release" to store various stuff. */ -}}
+{{- if not (index .Release "tmp_vars") -}}
+{{-   $_ := set .Release "tmp_vars" dict -}}
+{{- end -}}
+{{- /* Some random ID of this password, in case there will be other random values alongside this instance. */ -}}
+{{- $key := printf "%s_%s" .Release.Name "DB_PASS" -}}
+{{- /* If a password isn't set and the $key does not yet exist in .Release.tmp_vars, then... */ -}}
+{{- if .Values.config.masterUserPassword -}}
+{{- /* ... set the specified password as $key */ -}}
+{{-   $_ := set .Release.tmp_vars $key (.Values.config.masterUserPassword) -}}
+{{- else -}}
+{{- if not (index .Release.tmp_vars $key) -}}
+{{- /* ... store random password under the $key */ -}}
+{{-   $_ := set .Release.tmp_vars $key (randAlphaNum 20) -}}
+{{- end -}}
+{{- end -}}
+{{- /* Retrieve previously generated value. */ -}}
+{{- index .Release.tmp_vars $key -}}
+{{- end -}}
+
+{{- define "random_pw_reusable" -}}
+  {{- if .Release.IsUpgrade -}}
+    {{- $data := default dict (lookup "v1" "Secret" .Release.Namespace (printf "%s.1" .Values.config.name)).data -}}
+    {{- if $data -}}
+      {{- index $data "DB_PASS" | b64dec -}}
+    {{- end -}}
+  {{- else -}}
+    {{- (include "generate_static_password" .) -}}
+  {{- end -}}
+{{- end -}}

--- a/addons/rds-postgresql-aurora/templates/db_instance.yaml
+++ b/addons/rds-postgresql-aurora/templates/db_instance.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBCluster
+metadata:
+  name: {{ .Values.config.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
+spec:
+  autoMinorVersionUpgrade: true
+  backupRetentionPeriod: 14
+  databaseName: {{ .Values.config.name | snakecase | nospace }}
+  dbSubnetGroupRef:
+    from:
+      name: {{ .Values.config.name }}
+  copyTagsToSnapshot: true
+  dbClusterIdentifier: {{ .Values.config.name }}
+  enableCloudwatchLogsExports:
+    - postgresql
+  engine: aurora-postgresql
+  engineVersion: "{{ .Values.config.engineVersion }}"
+  masterUsername: adminer
+  masterUsername: "{{ .Values.config.masterUsername }}"
+{{ if eq .Values.config.instanceClass "db.serverless" }}
+  serverlessV2ScalingConfiguration:
+    maxCapacity: {{ .Values.config.serverlessMaxCapacity }}
+    minCapacity: {{ .Values.config.serverlessMinCapacity }}
+{{ end }}
+  masterUserPassword:
+    namespace: porter-env-group
+    name: {{ .Values.config.name }}.1
+    key: DB_PASS
+  monitoringInterval: 60
+  storageEncrypted: true
+  tags:
+    - key: "porter.run/managed"
+      value: "true"
+  vpcSecurityGroupRefs:
+    - from:
+        name: {{ .Values.config.name }}-rds
+{{ $name := .Values.config.name }}
+{{ $namespace := .Release.Namespace }}
+{{ $awsRegion := .Values.vpcConfig.awsRegion }}
+{{ $instanceClass := .Values.config.instanceClass }}
+{{ $engineVersion := .Values.config.engineVersion }}
+{{ $instanceCount := (.Values.config.instanceCount | int) }}
+{{ if eq .Values.config.instanceClass "db.serverless" }}
+{{ $instanceCount = 1}}
+{{ end }}
+{{ range $i, $e := until $instanceCount }}
+---
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBInstance
+metadata:
+  name: "{{ $name }}-{{ add1 $e }}"
+  namespace: "{{ $namespace }}"
+  annotations:
+    services.k8s.aws/region: "{{ $awsRegion }}"
+spec:
+  caCertificateIdentifier: rds-ca-rsa2048-g1
+  dbInstanceIdentifier: "{{ $name }}-{{ add1 $e }}"
+  dbClusterIdentifier: "{{ $name }}"
+  dbInstanceClass: "{{ $instanceClass }}"
+  engine: aurora-postgresql
+  engineVersion: "{{ $engineVersion }}"
+  performanceInsightsEnabled: true
+  performanceInsightsRetentionPeriod: 7
+  publiclyAccessible: false
+  tags:
+    - key: "porter.run/managed"
+      value: "true"
+{{ end }}

--- a/addons/rds-postgresql-aurora/templates/parameter_group.yaml
+++ b/addons/rds-postgresql-aurora/templates/parameter_group.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBParameterGroup
+metadata:
+  name: {{ .Values.config.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
+spec:
+  name: {{ .Values.config.name }}
+  description: "Parameter group for {{ .Values.config.name }}"
+  family: postgres{{ (semver (toString .Values.config.engineVersion)).Major }}
+  parameterOverrides:
+    max_wal_senders: "20"
+  tags:
+    - key: "porter.run/managed"
+      value: "true"

--- a/addons/rds-postgresql-aurora/templates/secret.yaml
+++ b/addons/rds-postgresql-aurora/templates/secret.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Values.config.name }}.1
+  namespace: porter-env-group
+  labels:
+    porter.run/environment-group-name: {{ .Values.config.name }}.1
+    porter.run/environment-group-version: "1"
+    porter.run/environment-group-datastore: {{ .Values.config.name }}
+    porter.run/environment-group-datastore-type: postgresql-aurora
+data:
+  DB_PASS: "{{- include "random_pw_reusable" . | b64enc }}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.config.name }}.1
+  namespace: porter-env-group
+  labels:
+    porter.run/environment-group-name: {{ .Values.config.name }}.1
+    porter.run/environment-group-version: "1"
+    porter.run/environment-group-datastore: {{ .Values.config.name }}
+    porter.run/environment-group-datastore-type: postgresql-aurora
+data:
+  DB_PORT: "5432"
+  DB_USER: {{ .Values.config.masterUsername }}
+---
+apiVersion: services.k8s.aws/v1alpha1
+kind: FieldExport
+metadata:
+  name: {{ .Values.config.name }}-host
+  namespace: {{ .Release.Namespace }}
+spec:
+  to:
+    name: {{ .Values.config.name }}.1
+    namespace: porter-env-group
+    key: DB_HOST
+    kind: configmap
+  from:
+    path: ".status.endpoint.address"
+    resource:
+      group: rds.services.k8s.aws
+      kind: DBInstance
+      name: {{ .Values.config.name }}

--- a/addons/rds-postgresql-aurora/templates/security_group.yaml
+++ b/addons/rds-postgresql-aurora/templates/security_group.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: {{ .Values.config.name }}-rds
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
+spec:
+  name: {{ .Values.config.name }}-rds
+  description: "Security Group for {{ .Values.config.name }} PostgresQL Aurora"
+  vpcID: {{ .Values.vpcConfig.vpcID }}
+  ingressRules:
+  - ipProtocol: tcp
+    ipRanges:
+    - cidrIP: "0.0.0.0/0"
+    fromPort: 5432
+    toPort: 5432
+  tags:
+    - key: "Name"
+      value: "{{ .Values.config.name }}-rds"
+    - key: "porter.run/managed"
+      value: "true"

--- a/addons/rds-postgresql-aurora/templates/subnets.yaml
+++ b/addons/rds-postgresql-aurora/templates/subnets.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBSubnetGroup
+metadata:
+  name: {{ .Values.config.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
+spec:
+  name: {{ .Values.config.name }}
+  description: "{{ .Values.config.name }} PostgresQL Aurora Subnet Group"
+{{- if .Values.vpcConfig.subnetIDs }}
+  subnetIDs:
+  {{- range .Values.vpcConfig.subnetIDs }}
+    - {{ toYaml . }}
+  {{- end}}
+{{- end }}
+  tags:
+    - key: "porter.run/managed"
+      value: "true"

--- a/addons/rds-postgresql-aurora/values.yaml
+++ b/addons/rds-postgresql-aurora/values.yaml
@@ -1,0 +1,14 @@
+config:
+  engineVersion: 15.4
+  instanceClass: db.t4g.medium
+  masterUsername: root
+  masterUserPassword: ""
+  name: ""
+  instanceCount: 2
+  serverlessMinCapacity: 0.5
+  serverlessMaxCapacity: 128
+
+vpcConfig:
+  awsRegion: ""
+  subnetIDs: []
+  vpcID: ""


### PR DESCRIPTION
This chart will allow users to provision either serverless or normal aurora clusters, respecting the specified instanceCount for scaling.

Note that since you can't have two RDS instances named the same on different engines, there isn't any aurora-specific namespacing of created resources.

Additionally, we use a separate chart than the existing postgresql chart as the implementation is different - rather than embedding a bunch of conditionals that make it harder to grok, we optimize for clarity and future contribution/maintenance burden.