### PR TITLE
feat: add release-name label to every porter-managed ack resource to allow for easier filtering.

### DIFF
--- a/addons/rds-postgresql-aurora/templates/db_instance.yaml
+++ b/addons/rds-postgresql-aurora/templates/db_instance.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
+  labels:
+    porter.run/helm-release-name: "{{ .Release.Name }}"
 spec:
   autoMinorVersionUpgrade: true
   backupRetentionPeriod: 14
@@ -44,6 +46,7 @@ spec:
 {{ $instanceClass := .Values.config.instanceClass }}
 {{ $engineVersion := .Values.config.engineVersion }}
 {{ $instanceCount := (.Values.config.instanceCount | int) }}
+{{ $releaseName := .Release.Name }}
 {{ if eq .Values.config.instanceClass "db.serverless" }}
 {{ $instanceCount = 1}}
 {{ end }}
@@ -56,6 +59,8 @@ metadata:
   namespace: "{{ $namespace }}"
   annotations:
     services.k8s.aws/region: "{{ $awsRegion }}"
+  labels:
+    porter.run/helm-release-name: "{{ $releaseName }}"
 spec:
   caCertificateIdentifier: rds-ca-rsa2048-g1
   dbInstanceIdentifier: "{{ $name }}-{{ add1 $e }}"

--- a/addons/rds-postgresql-aurora/templates/parameter_group.yaml
+++ b/addons/rds-postgresql-aurora/templates/parameter_group.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
+  labels:
+    porter.run/helm-release-name: "{{ .Release.Name }}"
 spec:
   name: {{ .Values.config.name }}
   description: "Parameter group for {{ .Values.config.name }}"

--- a/addons/rds-postgresql-aurora/templates/secret.yaml
+++ b/addons/rds-postgresql-aurora/templates/secret.yaml
@@ -10,6 +10,7 @@ metadata:
     porter.run/environment-group-version: "1"
     porter.run/environment-group-datastore: {{ .Values.config.name }}
     porter.run/environment-group-datastore-type: postgresql-aurora
+    porter.run/helm-release-name: "{{ .Release.Name }}"
 data:
   DB_PASS: "{{- include "random_pw_reusable" . | b64enc }}"
 ---
@@ -23,6 +24,7 @@ metadata:
     porter.run/environment-group-version: "1"
     porter.run/environment-group-datastore: {{ .Values.config.name }}
     porter.run/environment-group-datastore-type: postgresql-aurora
+    porter.run/helm-release-name: "{{ .Release.Name }}"
 data:
   DB_PORT: "5432"
   DB_USER: {{ .Values.config.masterUsername }}
@@ -32,6 +34,8 @@ kind: FieldExport
 metadata:
   name: {{ .Values.config.name }}-host
   namespace: {{ .Release.Namespace }}
+  labels:
+    porter.run/helm-release-name: "{{ .Release.Name }}"
 spec:
   to:
     name: {{ .Values.config.name }}.1

--- a/addons/rds-postgresql-aurora/templates/security_group.yaml
+++ b/addons/rds-postgresql-aurora/templates/security_group.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
+  labels:
+    porter.run/helm-release-name: "{{ .Release.Name }}"
 spec:
   name: {{ .Values.config.name }}-rds
   description: "Security Group for {{ .Values.config.name }} PostgresQL Aurora"

--- a/addons/rds-postgresql-aurora/templates/subnets.yaml
+++ b/addons/rds-postgresql-aurora/templates/subnets.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
+  labels:
+    porter.run/helm-release-name: "{{ .Release.Name }}"
 spec:
   name: {{ .Values.config.name }}
   description: "{{ .Values.config.name }} PostgresQL Aurora Subnet Group"

--- a/addons/rds-postgresql/templates/db_instance.yaml
+++ b/addons/rds-postgresql/templates/db_instance.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
+  labels:
+    porter.run/helm-release-name: "{{ .Release.Name }}"
 spec:
   allocatedStorage: {{ .Values.config.allocatedStorage }}
   autoMinorVersionUpgrade: true

--- a/addons/rds-postgresql/templates/parameter_group.yaml
+++ b/addons/rds-postgresql/templates/parameter_group.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
+  labels:
+    porter.run/helm-release-name: "{{ .Release.Name }}"
 spec:
   name: {{ .Values.config.name }}
   description: "Parameter group for {{ .Values.config.name }}"

--- a/addons/rds-postgresql/templates/secret.yaml
+++ b/addons/rds-postgresql/templates/secret.yaml
@@ -10,6 +10,7 @@ metadata:
     porter.run/environment-group-version: "1"
     porter.run/environment-group-datastore: {{ .Values.config.name }}
     porter.run/environment-group-datastore-type: postgresql
+    porter.run/helm-release-name: "{{ .Release.Name }}"
 data:
   DB_PASS: "{{- include "random_pw_reusable" . | b64enc }}"
 ---
@@ -23,6 +24,7 @@ metadata:
     porter.run/environment-group-version: "1"
     porter.run/environment-group-datastore: {{ .Values.config.name }}
     porter.run/environment-group-datastore-type: postgresql
+    porter.run/helm-release-name: "{{ .Release.Name }}"
 data:
   DB_PORT: "5432"
   DB_USER: {{ .Values.config.masterUsername }}
@@ -32,6 +34,8 @@ kind: FieldExport
 metadata:
   name: {{ .Values.config.name }}-host
   namespace: {{ .Release.Namespace }}
+  labels:
+    porter.run/helm-release-name: "{{ .Release.Name }}"
 spec:
   to:
     name: {{ .Values.config.name }}.1

--- a/addons/rds-postgresql/templates/security_group.yaml
+++ b/addons/rds-postgresql/templates/security_group.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
+  labels:
+    porter.run/helm-release-name: "{{ .Release.Name }}"
 spec:
   description: SecurityGroup
   name: {{ .Values.config.name }}-rds

--- a/addons/rds-postgresql/templates/subnets.yaml
+++ b/addons/rds-postgresql/templates/subnets.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     services.k8s.aws/region: {{ .Values.vpcConfig.awsRegion }}
+  labels:
+    porter.run/helm-release-name: "{{ .Release.Name }}"
 spec:
   name: {{ .Values.config.name }}
   description: "{{ .Values.config.name }} Subnet Group"


### PR DESCRIPTION
This will help if the underlying resource name is different from the release name - we can query the object type by release.