### PR TITLE
fix: if only the lock file changed, ignore it

### DIFF
--- a/addons/ack-chart/Chart.lock
+++ b/addons/ack-chart/Chart.lock
@@ -63,4 +63,4 @@ dependencies:
   repository: https://chart-addons.getporter.dev
   version: 1.0.6
 digest: sha256:5952da9d2455bff8918872f4704d264ecff88ef9044e7f1c248eafedf452f6cc
-generated: "2023-10-21T05:51:31.769660409Z"
+generated: "2023-10-21T05:51:31.769660409Zs"

--- a/scripts/rebuild-ack-chart
+++ b/scripts/rebuild-ack-chart
@@ -2,6 +2,7 @@
 set -eo pipefail
 main() {
   declare CHART_DIR="$1"
+  local lock_path="addons/ack-chart/Chart.lock"
   if [[ "$CHART_DIR" != "addons/ack-chart" ]]; then
     return
   fi
@@ -13,8 +14,9 @@ main() {
   helm dependency update "$CHART_DIR"
   echo "Building dependencies"
   helm dependency build "$CHART_DIR"
-  if [[ "$(git diff --name-only)" == "addons/ack-chart/Chart.lock" ]]; then
-    git checkout -- "addons/ack-chart/Chart.lock"
+
+  if [[ "$(git diff --name-only)" == "$lock_path" ]] && [[ "$(git diff --stat "$lock_path" | tail -n 1)" == " 1 file changed, 1 insertion(+), 1 deletion(-)" ]]; then
+    git checkout -- "$lock_path"
   fi
 }
 


### PR DESCRIPTION
In this case, only the 'generated' key would change.