### PR TITLE
fix: remove MonitoringInterval from cluster

### DIFF
--- a/addons/rds-postgresql-aurora/templates/db_instance.yaml
+++ b/addons/rds-postgresql-aurora/templates/db_instance.yaml
@@ -32,7 +32,6 @@ spec:
     namespace: porter-env-group
     name: {{ .Values.config.name }}.1
     key: DB_PASS
-  monitoringInterval: 0
   storageEncrypted: true
   tags:
     - key: "porter.run/managed"


### PR DESCRIPTION
It isn't supported there (and isn't in use anyways).