### PR TITLE
Enabled EDNS support by default.

### DIFF
--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -220,7 +220,8 @@ datadog:
 hostAliases: []
 
 # Set this for enabling DNS extensions over TCP
-enableEDNS0: false
+# We enable this by default.
+enableEDNS0: true
 
 nodeSelector: {}
 


### PR DESCRIPTION
This PR enables EDNS support by default, ensuring that web apps can trigger secondary DNS requests over TCP when the initial DNS response over UDP is truncated.