### PR TITLE
chore: remove extra .1 from env-group names

### DIFF
--- a/addons/elasticache-redis/templates/secret.yaml
+++ b/addons/elasticache-redis/templates/secret.yaml
@@ -6,10 +6,11 @@ metadata:
   name: "{{ .Values.config.name }}.1"
   namespace: porter-env-group
   labels:
-    porter.run/environment-group-name: "{{ .Values.config.name }}.1"
+    porter.run/environment-group-name: "{{ .Values.config.name }}"
     porter.run/environment-group-version: "1"
     porter.run/environment-group-datastore: "{{ .Values.config.name }}"
     porter.run/environment-group-datastore-type: redis
+    porter.run/managed=true
     porter.run/helm-release-name: "{{ .Release.Name }}"
 data:
   REDIS_PASS: "{{- include "random_pw_reusable" . | b64enc }}"
@@ -20,10 +21,11 @@ metadata:
   name: "{{ .Values.config.name }}.1"
   namespace: porter-env-group
   labels:
-    porter.run/environment-group-name: "{{ .Values.config.name }}.1"
+    porter.run/environment-group-name: "{{ .Values.config.name }}"
     porter.run/environment-group-version: "1"
     porter.run/environment-group-datastore: "{{ .Values.config.name }}"
     porter.run/environment-group-datastore-type: redis
+    porter.run/managed=true
     porter.run/helm-release-name: "{{ .Release.Name }}"
 ---
 apiVersion: services.k8s.aws/v1alpha1

--- a/addons/rds-postgresql-aurora/templates/secret.yaml
+++ b/addons/rds-postgresql-aurora/templates/secret.yaml
@@ -6,10 +6,11 @@ metadata:
   name: "{{ .Values.config.name }}.1"
   namespace: porter-env-group
   labels:
-    porter.run/environment-group-name: "{{ .Values.config.name }}.1"
+    porter.run/environment-group-name: "{{ .Values.config.name }}"
     porter.run/environment-group-version: "1"
     porter.run/environment-group-datastore: "{{ .Values.config.name }}"
     porter.run/environment-group-datastore-type: postgresql-aurora
+    porter.run/managed=true
     porter.run/helm-release-name: "{{ .Release.Name }}"
 data:
   DB_PASS: "{{- include "random_pw_reusable" . | b64enc }}"
@@ -20,10 +21,11 @@ metadata:
   name: "{{ .Values.config.name }}.1"
   namespace: porter-env-group
   labels:
-    porter.run/environment-group-name: "{{ .Values.config.name }}.1"
+    porter.run/environment-group-name: "{{ .Values.config.name }}"
     porter.run/environment-group-version: "1"
     porter.run/environment-group-datastore: "{{ .Values.config.name }}"
     porter.run/environment-group-datastore-type: postgresql-aurora
+    porter.run/managed=true
     porter.run/helm-release-name: "{{ .Release.Name }}"
 data:
   DB_PORT: "5432"

--- a/addons/rds-postgresql/templates/secret.yaml
+++ b/addons/rds-postgresql/templates/secret.yaml
@@ -6,10 +6,11 @@ metadata:
   name: "{{ .Values.config.name }}.1"
   namespace: porter-env-group
   labels:
-    porter.run/environment-group-name: "{{ .Values.config.name }}.1"
+    porter.run/environment-group-name: "{{ .Values.config.name }}"
     porter.run/environment-group-version: "1"
     porter.run/environment-group-datastore: "{{ .Values.config.name }}"
     porter.run/environment-group-datastore-type: postgresql
+    porter.run/managed=true
     porter.run/helm-release-name: "{{ .Release.Name }}"
 data:
   DB_PASS: "{{- include "random_pw_reusable" . | b64enc }}"
@@ -20,10 +21,11 @@ metadata:
   name: "{{ .Values.config.name }}.1"
   namespace: porter-env-group
   labels:
-    porter.run/environment-group-name: "{{ .Values.config.name }}.1"
+    porter.run/environment-group-name: "{{ .Values.config.name }}"
     porter.run/environment-group-version: "1"
     porter.run/environment-group-datastore: "{{ .Values.config.name }}"
     porter.run/environment-group-datastore-type: postgresql
+    porter.run/managed=true
     porter.run/helm-release-name: "{{ .Release.Name }}"
 data:
   DB_PORT: "5432"


### PR DESCRIPTION
The version is already encoded into the label.

Also add porter.run/managed=true as a label.