### PR TITLE
set cpu limit same as request

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -126,6 +126,7 @@ spec:
                 cpu: {{ .Values.resources.requests.cpu }}
                 memory: {{ .Values.resources.requests.memory }}
               limits:
+                cpu: {{ .Values.resources.requests.cpu }}
                 memory: {{ .Values.resources.requests.memory }}
           - name: sidecar
             image: public.ecr.aws/o1j4x7p4/job-sidecar:latest
@@ -140,6 +141,7 @@ spec:
                 cpu: {{ .Values.sidecar.resources.requests.cpu }}
                 memory: {{ .Values.sidecar.resources.requests.memory }}
               limits:
+                cpu: {{ .Values.sidecar.resources.requests.cpu }}
                 memory: {{ .Values.sidecar.resources.requests.memory }}
             command:
             - "./job_killer.sh"

--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -129,6 +129,7 @@ data:
                 cpu: {{ .Values.resources.requests.cpu }}
                 memory: {{ .Values.resources.requests.memory }}
               limits:
+                cpu: {{ .Values.resources.requests.cpu }}
                 memory: {{ .Values.resources.requests.memory }}
           - name: sidecar
             image: public.ecr.aws/o1j4x7p4/job-sidecar:latest
@@ -138,6 +139,7 @@ data:
                 cpu: {{ .Values.sidecar.resources.requests.cpu }}
                 memory: {{ .Values.sidecar.resources.requests.memory }}
               limits:
+                cpu: {{ .Values.sidecar.resources.requests.cpu }}
                 memory: {{ .Values.sidecar.resources.requests.memory }}
             {{- if (.Values.sidecar.timeout) }}
             env:

--- a/applications/job/templates/hook-delete.yaml
+++ b/applications/job/templates/hook-delete.yaml
@@ -37,6 +37,7 @@ spec:
             cpu: 10m
             memory: 32Mi
           limits:
+            cpu: 10m
             memory: 32Mi
       tolerations:
         - key: "removable"

--- a/applications/job/templates/hook.yaml
+++ b/applications/job/templates/hook.yaml
@@ -41,6 +41,7 @@ spec:
             cpu: 10m
             memory: 32Mi
           limits:
+            cpu: 10m
             memory: 32Mi
         volumeMounts:
         - name: manifest-data

--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -162,6 +162,7 @@ spec:
               cpu: {{ $.Values.resources.requests.cpu }}
               memory: {{ $.Values.resources.requests.memory }}
             limits:
+              cpu: {{ $.Values.resources.requests.cpu }}
               memory: {{ $.Values.resources.requests.memory }}
           env:
             # Porter default environment variables

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -204,6 +204,7 @@ spec:
           {{ end }}
           {{ end }}
             limits:
+              cpu: {{ .Values.resources.requests.cpu }}
               memory: {{ .Values.resources.requests.memory }}
           {{ if .Values.resources.limits }}
           {{ if .Values.resources.limits.nvidiaGpu }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -167,6 +167,7 @@ spec:
           {{ end }}
           {{ end }}
             limits:
+              cpu: {{ .Values.resources.requests.cpu }}
               memory: {{ .Values.resources.requests.memory }}
           {{ if .Values.resources.limits }}
           {{ if .Values.resources.limits.nvidiaGpu }}


### PR DESCRIPTION
In the implementation of hosted projects, we will be using Resource Quotas to constrain the consumption of individual users on the shared cluster. CPU limits needs to be set, and I am starting with using the request value until there is a specific need to have different limits vs requests.