### PR TITLE
increase healthcheck failure threshold

### DIFF
--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -149,7 +149,7 @@ health:
     periodSeconds: 5
     timeoutSeconds: 1
     successThreshold: 1
-    failureThreshold: 6
+    failureThreshold: 10
     httpHeaders: []
     auth:
       enabled: false
@@ -173,7 +173,7 @@ health:
     periodSeconds: 5
     timeoutSeconds: 1
     successThreshold: 1
-    failureThreshold: 6
+    failureThreshold: 10
     httpHeaders: []
     auth:
       enabled: false


### PR DESCRIPTION
10 seconds initial delay + 10 checks * 5 seconds / check = 60 seconds full healthcheck timeout