### PR TITLE
fix: use correct path for aurora db address

### DIFF
--- a/addons/rds-postgresql-aurora/templates/secret.yaml
+++ b/addons/rds-postgresql-aurora/templates/secret.yaml
@@ -45,7 +45,7 @@ spec:
     key: DB_HOST
     kind: configmap
   from:
-    path: ".status.endpoint.address"
+    path: ".status.endpoint"
     resource:
       group: rds.services.k8s.aws
       kind: DBCluster


### PR DESCRIPTION
This differs from postgres due to having a reader and a writer. Without this, the aurora DB_HOST shows as pending for exporting to the env group.