### PR TITLE
Patch: CPU limits for blue/green deployments

### DIFF
--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -162,7 +162,7 @@ spec:
               cpu: {{ $.Values.resources.requests.cpu }}
               memory: {{ $.Values.resources.requests.memory }}
             limits:
-              {{- if (.Values.resources.setCPULimits) }}
+              {{- if ($.Values.resources.setCPULimits) }}
               cpu: {{ $.Values.resources.requests.cpu }}
               {{ end }}
               memory: {{ $.Values.resources.requests.memory }}


### PR DESCRIPTION
Patched the web chart's blue/green deployment template to ensure that `.Values.setCPULimit` is being pulled in via `$`.