### PR TITLE
feat: sync the cloudwatch ack chart

### DIFF
--- a/.github/workflows/sync-remote-helm-charts.yaml
+++ b/.github/workflows/sync-remote-helm-charts.yaml
@@ -1,4 +1,4 @@
-name: 'Sync remote charts in PR'
+name: "Sync remote charts in PR"
 on:
   push:
     branches:
@@ -33,6 +33,10 @@ jobs:
             remote_repository: cloudtrail-controller
             remote_directory: helm
             target_directory: addons/cloudtrail-chart
+          - remote_owner: aws-controllers-k8s
+            remote_repository: cloudwatch-controller
+            remote_directory: helm
+            target_directory: addons/cloudwatch-chart
           - remote_owner: aws-controllers-k8s
             remote_repository: dynamodb-controller
             remote_directory: helm
@@ -119,7 +123,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: azure/setup-helm@v3
         with:
-          version: 'v3.3.4'
+          version: "v3.3.4"
       - name: Update remote chart
         uses: ./.github/actions/sync-remote-directory
         with:

--- a/vendored-charts
+++ b/vendored-charts
@@ -3,6 +3,7 @@ addons/apigatewayv2-chart
 addons/applicationautoscaling-chart
 addons/aws-cloudwatch-metrics
 addons/cloudtrail-chart
+addons/cloudwatch-chart
 addons/dynamodb-chart
 addons/ec2-chart
 addons/ecr-chart


### PR DESCRIPTION
This isn't installed by the umbrella chart and so wasn't initially added to the synced charts list.

It is necessary to allow us to manage cloudwatch via ACK resources.