### PR TITLE
feat: match the cloudsql proxy term_timeout to the passed terminationGracePeriodSeconds value

### DIFF
--- a/addons/helm-revision-pruner/templates/cronjob.yaml
+++ b/addons/helm-revision-pruner/templates/cronjob.yaml
@@ -141,6 +141,9 @@ spec:
               - "/cloud_sql_proxy"
               - "-instances={{ .Values.cloudsql.connectionName }}=tcp:{{ .Values.cloudsql.dbPort }}"
               - "-credential_file=/secrets/service_account.json"
+              {{ if .Values.terminationGracePeriodSeconds }}
+              - "-term_timeout={{ .Values.terminationGracePeriodSeconds }}s"
+              {{ end }}
             securityContext:
               runAsNonRoot: true
             volumeMounts:

--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -165,6 +165,9 @@ spec:
               - "/cloud_sql_proxy"
               - "-instances={{ .Values.cloudsql.connectionName }}=tcp:{{ .Values.cloudsql.dbPort }}"
               - "-credential_file=/secrets/service_account.json"
+              {{ if .Values.terminationGracePeriodSeconds }}
+              - "-term_timeout={{ .Values.terminationGracePeriodSeconds }}s"
+              {{ end }}
             securityContext:
               runAsNonRoot: true
             volumeMounts:

--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -168,6 +168,9 @@ data:
               - "/cloud_sql_proxy"
               - "-instances={{ .Values.cloudsql.connectionName }}=tcp:{{ .Values.cloudsql.dbPort }}"
               - "-credential_file=/secrets/service_account.json"
+              {{ if .Values.terminationGracePeriodSeconds }}
+              - "-term_timeout={{ .Values.terminationGracePeriodSeconds }}s"
+              {{ end }}
             securityContext:
               runAsNonRoot: true
             volumeMounts:

--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -231,6 +231,9 @@ spec:
             - "/cloud_sql_proxy"
             - "-instances={{ $.Values.cloudsql.connectionName }}=tcp:{{ $.Values.cloudsql.dbPort }}"
             - "-credential_file=/secrets/service_account.json"
+            {{ if $.Values.terminationGracePeriodSeconds }}
+            - "-term_timeout={{ $.Values.terminationGracePeriodSeconds }}s"
+            {{ end }}
           securityContext:
             runAsNonRoot: true
           volumeMounts:

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -323,6 +323,9 @@ spec:
             - "-instances={{ .Values.cloudsql.connectionName }}=tcp:{{ .Values.cloudsql.dbPort }}"
             {{- end }}
             - "-credential_file=/secrets/service_account.json"
+            {{ if .Values.terminationGracePeriodSeconds }}
+            - "-term_timeout={{ .Values.terminationGracePeriodSeconds }}s"
+            {{ end }}
           securityContext:
             runAsNonRoot: true
           resources:

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -260,6 +260,9 @@ spec:
             - "/cloud_sql_proxy"
             - "-instances={{ .Values.cloudsql.connectionName }}=tcp:{{ .Values.cloudsql.dbPort }}"
             - "-credential_file=/secrets/service_account.json"
+            {{ if .Values.terminationGracePeriodSeconds }}
+            - "-term_timeout={{ .Values.terminationGracePeriodSeconds }}s"
+            {{ end }}
           securityContext:
             runAsNonRoot: true
           volumeMounts:


### PR DESCRIPTION
By default, CloudSQL Proxy does not wait after a SIGTERM before shutting down the proxy. For applications that gracefully shutdown, a pod may receive a SIGTERM and wait some number of seconds before receiving a SIGKILL. The CloudSQL Proxy will terminate immediately, so any in-flight requests that create new connections during that time will receive an ECONNREFUSED, while any existing connections may receive an ECONNABORTED, resulting in errors propagating up to end-users.

This change sets the `-term_timeout` flag to match terminationGracePeriodSeconds for the CloudSQL Proxy process. Connections will wait at least that amount of time before terminating. CloudSQL may abort if in-flight connections terminate early, but this is safer than refusing connections completely (apps should drain connections rather than continue to create requests).

Note that there is a trailing `s` character for the value. See the following links for more information.

- https://github.com/GoogleCloudPlatform/cloud-sql-proxy/blob/v1.33.15/README.md#-term_timeout30s
- https://github.com/GoogleCloudPlatform/cloud-sql-proxy/issues/1742#issuecomment-1568886109