### PR TITLE
emptyDir: volume options

### DIFF
--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -395,7 +395,8 @@ spec:
         {{ end }}
         {{ if .Values.emptyDir.enabled }}
         - name: "{{ include "docker-template.fullname" . }}-empty-dir-storage"
-          emptyDir: {}
+          emptyDir:
+            {{- toYaml .Values.emptyDir.volumeOptions | nindent 8 }}
         {{ end }}
       {{ end }}
 {{- end }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -255,3 +255,4 @@ stack:
 emptyDir:
   enabled: false
   mountPath: /mypath
+  volumeOptions: {}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -311,6 +311,7 @@ spec:
         {{ end }}
         {{ if .Values.emptyDir.enabled }}
         - name: "{{ include "docker-template.fullname" . }}-empty-dir-storage"
-          emptyDir: {}
+          emptyDir:
+            {{- toYaml .Values.emptyDir.volumeOptions | nindent 8 }}
         {{ end }}
       {{ end }}

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -137,3 +137,4 @@ stack:
 emptyDir:
   enabled: false
   mountPath: /mypath
+  volumeOptions: {}


### PR DESCRIPTION
This would allow us to increase the size of `/dev/shm` (default is `64 Mi`):

```yaml
# values.yaml
emptyDir:
  enabled: true
  mountPath: /dev/shm
  volumeOptions:
    medium: Memory
    sizeLimit: 2G
```