### PR TITLE
Reversed wildcard switch for certificates

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -64,7 +64,7 @@ spec:
     - hosts:
         - {{ . | quote }}
       {{- if not $.Values.ingress.useDefaultIngressTLSSecret }}
-      {{ if and $.Values.ingress.wildcard (hasPrefix "*" .) }}
+      {{ if $.Values.ingress.wildcard }}
       secretName: wildcard-cert-tls
       {{ else if $.Values.ingress.customTls.enabled }}
       secretName: {{ $.Values.ingress.customTls.customTlsSecret }}


### PR DESCRIPTION
Reversed a change made in #1121 where we were trying to assign wildcard certs only to wildcard domains.