### PR TITLE
Added support for EDNS to the job chart.

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -49,6 +49,11 @@ spec:
             {{- toYaml .Values.podLabels | nindent 12 }}
             {{- end }}
         spec:
+          {{- if .Values.enableEDNS0 }}
+          dnsConfig:
+            options:
+              - name: edns0
+          {{- end }}
           {{- if .Values.serviceAccount.create }}
           serviceAccountName: cronjob-{{ include "docker-template.serviceAccountName" . }}
           {{ else }}

--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -59,6 +59,11 @@ data:
           {{ else }}
           serviceAccountName: {{ include "docker-template.serviceAccountName" . }}
           {{- end }}
+          {{- if .Values.enableEDNS0 }}
+          dnsConfig:
+            options:
+              - name: edns0
+          {{- end }}
           containers:
           - name: {{ .Chart.Name }}
             {{- if .Values.global }}

--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -50,6 +50,10 @@ cloudsql:
   dbPort: 5432
   serviceAccountJSON: ""
 
+# Set this for enabling DNS extensions over TCP
+# We enable this by default.
+enableEDNS0: true
+
 sidecar:
   signalChildProcesses: true
   # The timeout value in seconds for the job run


### PR DESCRIPTION
This PR adds support for Extension Mechanisms for DNS(EDNS) to the job chart. The behaviour is the same as for web and worker charts; we set `enableEDNS0` to `true` by default, which injects a `dnsConfig` object with an `options` list containing the `edns0` option at `spec.template.spec.dnsConfig` for the job hook, and `spec.jobTemplate.spec.template.spec.dnsConfig` for the `CronJob`. This will ensure that if a job runs into a DNS response(typically by OpenAI) which is larger than the UDP packet size limit, the job will make the same DNS request over TCP.