### PR TITLE
cronjob rbac perms for porter-agent

### DIFF
--- a/addons/porter-agent/templates/rbac.yaml
+++ b/addons/porter-agent/templates/rbac.yaml
@@ -84,6 +84,7 @@ rules:
       - "batch"
     resources:
       - "jobs"
+      - "cronjobs"
     verbs:
       - get
       - list


### PR DESCRIPTION
Adds permissions to get, list, watch cronjobs from the porter-agent