### PR TITLE
Adding Elasticsearch addon support for K8s 1.25+

### DIFF
--- a/addons/elasticsearch/templates/poddisruptionbudget.yaml
+++ b/addons/elasticsearch/templates/poddisruptionbudget.yaml
@@ -1,6 +1,10 @@
 ---
 {{- if .Values.maxUnavailable }}
+{{- if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "elasticsearch.uname" . }}-pdb"


### PR DESCRIPTION
The PodDisruptionBudget resource uses policy/v1beta1. But, according to [docs](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125), this API is not supported for K8s 1.25+, needing migration to policy/v1 API.

This PR checks if policy/v1/PodDisruptionBudget is available and uses policy/v1 if so.

Also I've tested it using Minikube with clusters from 1.24 to 1.27.

@rudimk please review this.