### PR TITLE
Support for imagePullSecrets

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -59,7 +59,7 @@ spec:
           {{ else }}
           serviceAccountName: {{ include "docker-template.serviceAccountName" . }}
           {{- end }}
-          {{- if .Values.image.imagePullSecret }}
+          {{- if and (.Values.image) (.Values.image.imagePullSecret) }}
           imagePullSecrets:
             - name: {{ .Values.image.imagePullSecret }}
           {{- end }}

--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -59,6 +59,10 @@ spec:
           {{ else }}
           serviceAccountName: {{ include "docker-template.serviceAccountName" . }}
           {{- end }}
+          {{- if .Values.image.imagePullSecret }}
+          imagePullSecrets:
+            - name: {{ .Values.image.imagePullSecret }}
+          {{- end }}
           containers:
           - name: {{ .Chart.Name }}
             {{- if .Values.global }}

--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -67,6 +67,10 @@ data:
             options:
               - name: edns0
           {{- end }}
+          {{- if .Values.image.imagePullSecret }}
+          imagePullSecrets:
+            - name: {{ .Values.image.imagePullSecret }}
+          {{- end }}
           containers:
           - name: {{ .Chart.Name }}
             {{- if .Values.global }}

--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -67,7 +67,7 @@ data:
             options:
               - name: edns0
           {{- end }}
-          {{- if .Values.image.imagePullSecret }}
+          {{- if and (.Values.image) (.Values.image.imagePullSecret) }}
           imagePullSecrets:
             - name: {{ .Values.image.imagePullSecret }}
           {{- end }}

--- a/applications/job/templates/hook.yaml
+++ b/applications/job/templates/hook.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       serviceAccountName: {{ include "docker-template.fullname" . }}
       restartPolicy: Never
-      {{- if .Values.image.imagePullSecret }}
+      {{- if and (.Values.image) (.Values.image.imagePullSecret) }}
       imagePullSecrets:
         - name: {{ .Values.image.imagePullSecret }}
       {{- end }}

--- a/applications/job/templates/hook.yaml
+++ b/applications/job/templates/hook.yaml
@@ -23,6 +23,10 @@ spec:
     spec:
       serviceAccountName: {{ include "docker-template.fullname" . }}
       restartPolicy: Never
+      {{- if .Values.image.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.imagePullSecret }}
+      {{- end }}
       containers:
       - name: job-manager
         image: public.ecr.aws/o1j4x7p4/job-manager:latest

--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -14,6 +14,8 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: latest
+  # A single imagePullSecret that will be injected into the deployment; only use in extreme cases, else it must be left blank. 
+  imagePullSecret:
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -35,6 +35,10 @@ spec:
         options:
           - name: edns0
       {{- end }}
+      {{- if $.Values.image.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ $.Values.image.imagePullSecret }}
+      {{- end }}
       containers:
         - name: {{ $.Chart.Name }}
           securityContext:

--- a/applications/web/templates/deployment-blue-green.yaml
+++ b/applications/web/templates/deployment-blue-green.yaml
@@ -35,7 +35,7 @@ spec:
         options:
           - name: edns0
       {{- end }}
-      {{- if $.Values.image.imagePullSecret }}
+      {{- if and ($.Values.image) ($.Values.image.imagePullSecret) }}
       imagePullSecrets:
         - name: {{ $.Values.image.imagePullSecret }}
       {{- end }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -353,7 +353,10 @@ spec:
             mountPath: /secrets/
             readOnly: true
         {{ end }}
-     
+      {{- if .Values.image.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.imagePullSecret }}
+      {{- end }}
       {{- if gt (len .Values.nodeSelector) 0}}
       nodeSelector:
         {{- range $k, $v := .Values.nodeSelector }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -353,7 +353,7 @@ spec:
             mountPath: /secrets/
             readOnly: true
         {{ end }}
-      {{- if .Values.image.imagePullSecret }}
+      {{- if and (.Values.image) (.Values.image.imagePullSecret) }}
       imagePullSecrets:
         - name: {{ .Values.image.imagePullSecret }}
       {{- end }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -22,6 +22,8 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: latest
+  # A single imagePullSecret that will be injected into the deployment; only use in extreme cases, else it must be left blank. 
+  imagePullSecret:
 
 podLabels: {}
 

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -286,6 +286,10 @@ spec:
             mountPath: /secrets/
             readOnly: true
         {{ end }}
+      {{- if .Values.image.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.imagePullSecret }}
+      {{- end }}
       {{- if gt (len .Values.nodeSelector) 0}}
       nodeSelector:
         {{- range $k, $v := .Values.nodeSelector }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -286,7 +286,7 @@ spec:
             mountPath: /secrets/
             readOnly: true
         {{ end }}
-      {{- if .Values.image.imagePullSecret }}
+      {{- if and (.Values.image) (.Values.image.imagePullSecret) }}
       imagePullSecrets:
         - name: {{ .Values.image.imagePullSecret }}
       {{- end }}

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -20,6 +20,8 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: latest
+  # A single imagePullSecret that will be injected into the deployment; only use in extreme cases, else it must be left blank. 
+  imagePullSecret:
 
 podLabels: {}
 


### PR DESCRIPTION
Added basic support for manually specifying an optional `imagePullSecret` for situations where manually updating Porter app templates is necessary.