### PR TITLE
Add env vars for billing controller

### DIFF
--- a/addons/porter-agent/templates/configmap.yaml
+++ b/addons/porter-agent/templates/configmap.yaml
@@ -16,4 +16,3 @@ data:
   SQL_LITE: "true"
   SQL_LITE_PATH: "/porter/sqlite/agent.db"
   PROMETHEUS_URL: "{{ .Values.agent.prometheusURL }}"
-  METRONOME_API_KEY: "{{ .Values.agent.metronomeKey }}"

--- a/addons/porter-agent/templates/configmap.yaml
+++ b/addons/porter-agent/templates/configmap.yaml
@@ -17,4 +17,3 @@ data:
   SQL_LITE_PATH: "/porter/sqlite/agent.db"
   PROMETHEUS_URL: "{{ .Values.agent.prometheusURL }}"
   METRONOME_API_KEY: "{{ .Values.agent.metronomeKey }}"
-  

--- a/addons/porter-agent/templates/configmap.yaml
+++ b/addons/porter-agent/templates/configmap.yaml
@@ -17,3 +17,4 @@ data:
   SQL_LITE_PATH: "/porter/sqlite/agent.db"
   PROMETHEUS_URL: "{{ .Values.agent.prometheusURL }}"
   METRONOME_API_KEY: "{{ .Values.agent.metronomeKey }}"
+  

--- a/addons/porter-agent/templates/configmap.yaml
+++ b/addons/porter-agent/templates/configmap.yaml
@@ -4,16 +4,16 @@ metadata:
   name: porter-agent-config
   namespace: porter-agent-system
 data:
-  PORTER_HOST: '{{ .Values.agent.porterHost }}'
-  CF_ACCESS_TOKEN: '{{ .Values.agent.cfAccessToken }}'
-  PORTER_PORT: '{{ .Values.agent.porterPort }}'
-  PORTER_TOKEN: '{{ .Values.agent.porterToken }}'
-  CLUSTER_ID: '{{ .Values.agent.clusterID }}'
-  PROJECT_ID: '{{ .Values.agent.projectID }}'
-  LOG_STORE_KIND: 'loki'
-  LOG_STORE_ADDRESS: '{{ .Values.agent.lokiURL }}'
-  LOG_STORE_HTTP_ADDRESS: '{{ .Values.agent.lokiHTTPURL }}'
-  SQL_LITE: 'true'
-  SQL_LITE_PATH: '/porter/sqlite/agent.db'
-  PROMETHEUS_URL: '{{ .Values.agent.prometheusURL }}'
-  METRONOME_API_KEY: '{{ .Values.agent.metronomeKey }}'
+  PORTER_HOST: "{{ .Values.agent.porterHost }}"
+  CF_ACCESS_TOKEN: "{{ .Values.agent.cfAccessToken }}"
+  PORTER_PORT: "{{ .Values.agent.porterPort }}"
+  PORTER_TOKEN: "{{ .Values.agent.porterToken }}"
+  CLUSTER_ID: "{{ .Values.agent.clusterID }}"
+  PROJECT_ID: "{{ .Values.agent.projectID }}"
+  LOG_STORE_KIND: "loki"
+  LOG_STORE_ADDRESS: "{{ .Values.agent.lokiURL }}"
+  LOG_STORE_HTTP_ADDRESS: "{{ .Values.agent.lokiHTTPURL }}"
+  SQL_LITE: "true"
+  SQL_LITE_PATH: "/porter/sqlite/agent.db"
+  PROMETHEUS_URL: "{{ .Values.agent.prometheusURL }}"
+  METRONOME_API_KEY: "{{ .Values.agent.metronomeKey }}"

--- a/addons/porter-agent/templates/configmap.yaml
+++ b/addons/porter-agent/templates/configmap.yaml
@@ -4,14 +4,16 @@ metadata:
   name: porter-agent-config
   namespace: porter-agent-system
 data:
-  PORTER_HOST: "{{ .Values.agent.porterHost }}"
-  CF_ACCESS_TOKEN: "{{ .Values.agent.cfAccessToken }}"
-  PORTER_PORT: "{{ .Values.agent.porterPort }}"
-  PORTER_TOKEN: "{{ .Values.agent.porterToken }}"
-  CLUSTER_ID: "{{ .Values.agent.clusterID }}"
-  PROJECT_ID: "{{ .Values.agent.projectID }}"
-  LOG_STORE_KIND: "loki"
-  LOG_STORE_ADDRESS: "{{ .Values.agent.lokiURL }}"
-  LOG_STORE_HTTP_ADDRESS: "{{ .Values.agent.lokiHTTPURL }}"
-  SQL_LITE: "true"
-  SQL_LITE_PATH: "/porter/sqlite/agent.db"
+  PORTER_HOST: '{{ .Values.agent.porterHost }}'
+  CF_ACCESS_TOKEN: '{{ .Values.agent.cfAccessToken }}'
+  PORTER_PORT: '{{ .Values.agent.porterPort }}'
+  PORTER_TOKEN: '{{ .Values.agent.porterToken }}'
+  CLUSTER_ID: '{{ .Values.agent.clusterID }}'
+  PROJECT_ID: '{{ .Values.agent.projectID }}'
+  LOG_STORE_KIND: 'loki'
+  LOG_STORE_ADDRESS: '{{ .Values.agent.lokiURL }}'
+  LOG_STORE_HTTP_ADDRESS: '{{ .Values.agent.lokiHTTPURL }}'
+  SQL_LITE: 'true'
+  SQL_LITE_PATH: '/porter/sqlite/agent.db'
+  PROMETHEUS_URL: '{{ .Values.agent.prometheusURL }}'
+  METRONOME_API_KEY: '{{ .Values.agent.metronomeKey }}'

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -1,16 +1,18 @@
 agent:
-  image: "public.ecr.aws/o1j4x7p4/porter-agent:v3.2.7"
-  cfAccessToken: ""
-  porterHost: "dashboard.getporter.dev"
-  porterPort: "80"
-  porterToken: ""
+  image: 'public.ecr.aws/o1j4x7p4/porter-agent:v3.2.7'
+  cfAccessToken: ''
+  porterHost: 'dashboard.getporter.dev'
+  porterPort: '80'
+  porterToken: ''
   privateRegistry:
     enabled: false
-    secret: ""
-  clusterID: ""
-  projectID: ""
+    secret: ''
+  clusterID: ''
+  projectID: ''
   lokiURL: porter-agent-loki.porter-agent-system:9095
   lokiHTTPURL: http://porter-agent-loki.porter-agent-system:3100
+  prometheusURL: ''
+  metronomeKey: ''
 
 resources:
   limits:
@@ -53,7 +55,7 @@ loki:
     tolerations:
       - effect: NoSchedule
         key: porter.run/workload-kind
-        value: "monitoring"
+        value: 'monitoring'
         operator: Equal
     persistence:
       enabled: true
@@ -83,7 +85,7 @@ loki:
     initialDelaySeconds: 45
   datasource:
     jsonData: {}
-    uid: ""
+    uid: ''
   persistence:
     enabled: true
     size: 100Gi
@@ -105,15 +107,15 @@ promtail:
     # See https://github.com/grafana/helm-charts/blob/18282f1780c73130a89ba5e0ee0f8c5721f08b13/charts/promtail/values.yaml#L343
     snippets:
       extraRelabelConfigs:
-      - source_labels:
-          - __meta_kubernetes_namespace
-          - __meta_kubernetes_pod_name
-          - __meta_kubernetes_pod_annotation_helm_sh_revision
-        target_label: porter_pod_name
-        action: replace
-        separator: '_'
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels:
+            - __meta_kubernetes_namespace
+            - __meta_kubernetes_pod_name
+            - __meta_kubernetes_pod_annotation_helm_sh_revision
+          target_label: porter_pod_name
+          action: replace
+          separator: '_'
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
   resources:
     limits:
       memory: 256Mi

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -1,18 +1,18 @@
 agent:
-  image: 'public.ecr.aws/o1j4x7p4/porter-agent:v3.2.7'
-  cfAccessToken: ''
-  porterHost: 'dashboard.getporter.dev'
-  porterPort: '80'
-  porterToken: ''
+  image: "public.ecr.aws/o1j4x7p4/porter-agent:v3.2.7"
+  cfAccessToken: ""
+  porterHost: "dashboard.getporter.dev"
+  porterPort: "80"
+  porterToken: ""
   privateRegistry:
     enabled: false
-    secret: ''
-  clusterID: ''
-  projectID: ''
+    secret: ""
+  clusterID: ""
+  projectID: ""
   lokiURL: porter-agent-loki.porter-agent-system:9095
   lokiHTTPURL: http://porter-agent-loki.porter-agent-system:3100
-  prometheusURL: ''
-  metronomeKey: ''
+  prometheusURL: ""
+  metronomeKey: ""
 
 resources:
   limits:
@@ -55,7 +55,7 @@ loki:
     tolerations:
       - effect: NoSchedule
         key: porter.run/workload-kind
-        value: 'monitoring'
+        value: "monitoring"
         operator: Equal
     persistence:
       enabled: true
@@ -85,7 +85,7 @@ loki:
     initialDelaySeconds: 45
   datasource:
     jsonData: {}
-    uid: ''
+    uid: ""
   persistence:
     enabled: true
     size: 100Gi
@@ -107,15 +107,15 @@ promtail:
     # See https://github.com/grafana/helm-charts/blob/18282f1780c73130a89ba5e0ee0f8c5721f08b13/charts/promtail/values.yaml#L343
     snippets:
       extraRelabelConfigs:
-        - source_labels:
-            - __meta_kubernetes_namespace
-            - __meta_kubernetes_pod_name
-            - __meta_kubernetes_pod_annotation_helm_sh_revision
-          target_label: porter_pod_name
-          action: replace
-          separator: '_'
-        - action: labelmap
-          regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels:
+          - __meta_kubernetes_namespace
+          - __meta_kubernetes_pod_name
+          - __meta_kubernetes_pod_annotation_helm_sh_revision
+        target_label: porter_pod_name
+        action: replace
+        separator: '_'
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
   resources:
     limits:
       memory: 256Mi

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -11,8 +11,7 @@ agent:
   projectID: ""
   lokiURL: porter-agent-loki.porter-agent-system:9095
   lokiHTTPURL: http://porter-agent-loki.porter-agent-system:3100
-  prometheusURL: ""
-  metronomeKey: ""
+  prometheusURL: http://prometheus-server.monitoring.svc
 
 resources:
   limits:


### PR DESCRIPTION
This PR adds the `prometheusURL` value to the porter-agent helm chart so the billing changes inside the porter agent can be deployed

In the future this may be overriden to account for managed Prometheus.