### PR TITLE
Bump porter agent version to v3.2.11

### DIFF
--- a/addons/porter-agent/Chart.yaml
+++ b/addons/porter-agent/Chart.yaml
@@ -18,7 +18,7 @@ version: 0.29.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.2.5"
+appVersion: "3.2.11"
 dependencies:
   - name: "loki"
     repository: "https://chart-addons.getporter.dev"

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -1,14 +1,14 @@
 agent:
-  image: "public.ecr.aws/o1j4x7p4/porter-agent:v3.2.9"
-  cfAccessToken: ""
-  porterHost: "dashboard.getporter.dev"
-  porterPort: "80"
-  porterToken: ""
+  image: 'public.ecr.aws/o1j4x7p4/porter-agent:v3.2.11'
+  cfAccessToken: ''
+  porterHost: 'dashboard.getporter.dev'
+  porterPort: '80'
+  porterToken: ''
   privateRegistry:
     enabled: false
-    secret: ""
-  clusterID: ""
-  projectID: ""
+    secret: ''
+  clusterID: ''
+  projectID: ''
   lokiURL: porter-agent-loki.porter-agent-system:9095
   lokiHTTPURL: http://porter-agent-loki.porter-agent-system:3100
 
@@ -53,7 +53,7 @@ loki:
     tolerations:
       - effect: NoSchedule
         key: porter.run/workload-kind
-        value: "monitoring"
+        value: 'monitoring'
         operator: Equal
     persistence:
       enabled: true
@@ -83,7 +83,7 @@ loki:
     initialDelaySeconds: 45
   datasource:
     jsonData: {}
-    uid: ""
+    uid: ''
   persistence:
     enabled: true
     size: 100Gi
@@ -105,15 +105,15 @@ promtail:
     # See https://github.com/grafana/helm-charts/blob/18282f1780c73130a89ba5e0ee0f8c5721f08b13/charts/promtail/values.yaml#L343
     snippets:
       extraRelabelConfigs:
-      - source_labels:
-          - __meta_kubernetes_namespace
-          - __meta_kubernetes_pod_name
-          - __meta_kubernetes_pod_annotation_helm_sh_revision
-        target_label: porter_pod_name
-        action: replace
-        separator: '_'
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels:
+            - __meta_kubernetes_namespace
+            - __meta_kubernetes_pod_name
+            - __meta_kubernetes_pod_annotation_helm_sh_revision
+          target_label: porter_pod_name
+          action: replace
+          separator: '_'
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
   resources:
     limits:
       memory: 256Mi

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -1,5 +1,5 @@
 agent:
-  image: "public.ecr.aws/o1j4x7p4/porter-agent:v3.2.8"
+  image: "public.ecr.aws/o1j4x7p4/porter-agent:v3.2.9"
   cfAccessToken: ""
   porterHost: "dashboard.getporter.dev"
   porterPort: "80"

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -1,5 +1,5 @@
 agent:
-  image: "public.ecr.aws/o1j4x7p4/porter-agent:v3.2.7"
+  image: "public.ecr.aws/o1j4x7p4/porter-agent:v3.2.8"
   cfAccessToken: ""
   porterHost: "dashboard.getporter.dev"
   porterPort: "80"

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -1,14 +1,14 @@
 agent:
-  image: 'public.ecr.aws/o1j4x7p4/porter-agent:v3.2.11'
-  cfAccessToken: ''
-  porterHost: 'dashboard.getporter.dev'
-  porterPort: '80'
-  porterToken: ''
+  image: "public.ecr.aws/o1j4x7p4/porter-agent:v3.2.11"
+  cfAccessToken: ""
+  porterHost: "dashboard.getporter.dev"
+  porterPort: "80"
+  porterToken: ""
   privateRegistry:
     enabled: false
-    secret: ''
-  clusterID: ''
-  projectID: ''
+    secret: ""
+  clusterID: ""
+  projectID: ""
   lokiURL: porter-agent-loki.porter-agent-system:9095
   lokiHTTPURL: http://porter-agent-loki.porter-agent-system:3100
 
@@ -53,7 +53,7 @@ loki:
     tolerations:
       - effect: NoSchedule
         key: porter.run/workload-kind
-        value: 'monitoring'
+        value: "monitoring"
         operator: Equal
     persistence:
       enabled: true
@@ -83,7 +83,7 @@ loki:
     initialDelaySeconds: 45
   datasource:
     jsonData: {}
-    uid: ''
+    uid: ""
   persistence:
     enabled: true
     size: 100Gi
@@ -105,15 +105,15 @@ promtail:
     # See https://github.com/grafana/helm-charts/blob/18282f1780c73130a89ba5e0ee0f8c5721f08b13/charts/promtail/values.yaml#L343
     snippets:
       extraRelabelConfigs:
-        - source_labels:
-            - __meta_kubernetes_namespace
-            - __meta_kubernetes_pod_name
-            - __meta_kubernetes_pod_annotation_helm_sh_revision
-          target_label: porter_pod_name
-          action: replace
-          separator: '_'
-        - action: labelmap
-          regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels:
+          - __meta_kubernetes_namespace
+          - __meta_kubernetes_pod_name
+          - __meta_kubernetes_pod_annotation_helm_sh_revision
+        target_label: porter_pod_name
+        action: replace
+        separator: '_'
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
   resources:
     limits:
       memory: 256Mi


### PR DESCRIPTION
This PR changes the default version of porter agent to v3.2.11 so it deploys the consolidated agent with billing jobs.