### PR TITLE
Metabase - database notes

### DIFF
--- a/addons/metabase/README.md
+++ b/addons/metabase/README.md
@@ -1,3 +1,13 @@
 Metabase is an open source business intelligence tool. It lets you ask questions about your data, and displays answers in formats that make sense, whether that’s a bar graph or a detailed table.
 
 Your questions can be saved for later, making it easy to come back to them, or you can group questions into great looking dashboards. Metabase also makes it easy to share questions and dashboards with the rest of your team.
+
+## Prerequisites
+Please note that the Metabase addon uses an ephemeral in-memory database which is **not** recommended for production workloads. We recommend connecting Metabase to en external database which will ensure your dashbaords and metadata is accessible even if Metabase is restarted. In order to configure an external database, please use the following environment variables in the `Environment` section of the addon(in the next step):
+
+1. `MB_DB_TYPE`
+2. `MB_DB_DBNAME` 
+3. `MB_DB_PORT`
+4. `MB_DB_USER`
+5. `MB_DB_PASS`
+6. `MB_DB_HOST` 

--- a/addons/metabase/form.yaml
+++ b/addons/metabase/form.yaml
@@ -47,7 +47,7 @@ tabs:
     - type: heading
       label: Environment Variables
     - type: subtitle
-      label: Set environment variables for your secrets and environment-specific configuration. For configuring Metabase to use an external database to store its metadata, use the MB_DB_TYPE, MB_DB_DBNAME, MB_DB_PORT, MB_DB_USER, MB_DB_PASS and MB_DB_HOST environment variables.
+      label: Set environment variables for your secrets and environment-specific configuration. Please note that Metabase uses an ephemeral in-memory database which can be lost if the addon is restarted. For configuring Metabase to use an external database to store its metadata, use the MB_DB_TYPE, MB_DB_DBNAME, MB_DB_PORT, MB_DB_USER, MB_DB_PASS and MB_DB_HOST environment variables.
     - type: env-key-value-array
       label: 
       variable: container.env.normal


### PR DESCRIPTION
Added messaging about the ephemeral nature of Metabase's database and the need for configuring an external datastore.