### PR TITLE
Support for Datadog UDS volume mounts

### DIFF
--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -312,6 +312,10 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             {{ end }}
+            {{ if .Values.datadogSocketVolume.enabled }}
+            - name: DD_TRACE_AGENT_URL
+              value: "unix:///var/run/datadog/apm.socket"
+            {{ end }}
             {{- range $syncedEnv := .Values.container.env.synced }}
             {{- range $key := $syncedEnv.keys }}
             - name: {{ $key.name }}
@@ -332,6 +336,11 @@ spec:
             - name: PORT
               value: {{ .Values.container.port | quote }}
             {{- end }}
+        {{ if .Values.datadogSocketVolume.enabled }}
+          volumeMounts:
+            - name: apmsocketpath
+              mountPath: /var/run/datadog
+        {{ end }}
         {{ if .Values.awsEfsStorage }}
           volumeMounts:
         {{- range $v := .Values.awsEfsStorage }}
@@ -423,6 +432,11 @@ spec:
       {{ end }}
       {{ if or .Values.pvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.fileSecretMounts.enabled .Values.awsEfsStorage }}
       volumes:
+        {{ if .Values.datadogSocketVolume.enabled }}
+        - hostPath:
+            path: /var/run/datadog/
+          name: apmsocketpath
+        {{ end }}
         {{ if .Values.cloudsql.enabled }}
         - name: "sidecar-volume-{{ include "docker-template.fullname" . }}"
           secret:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -242,6 +242,9 @@ cloudsql:
 datadog:
   enabled: false
 
+datadogSocketVolume:
+  enabled: false
+
 # Set this to add entries to the /etc/hosts file
 # Format: hostAliases: [{ip: <IP>, hostnames: [<HOSTNAME>,..]},..]
 hostAliases: []

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -267,6 +267,10 @@ spec:
               value: {{ quote $val }}
             {{- end }}
             {{- end }}
+            {{ if .Values.datadogSocketVolume.enabled }}
+            - name: DD_TRACE_AGENT_URL
+              value: "unix:///var/run/datadog/apm.socket"
+            {{ end }}
             {{- range $syncedEnv := .Values.container.env.synced }}
             {{- range $key := $syncedEnv.keys }}
             - name: {{ $key.name }}
@@ -283,6 +287,11 @@ spec:
               {{- end }}
             {{- end }}
             {{- end }}
+          {{ if .Values.datadogSocketVolume.enabled }}
+          volumeMounts:
+            - name: apmsocketpath
+              mountPath: /var/run/datadog
+        {{ end }}
           {{ if .Values.pvc.enabled }}
           volumeMounts:
             - name: "{{ include "docker-template.fullname" . }}-storage"
@@ -355,6 +364,11 @@ spec:
       {{ end }}
       {{ if or .Values.pvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled }}
       volumes:
+        {{ if .Values.datadogSocketVolume.enabled }}
+        - hostPath:
+            path: /var/run/datadog/
+          name: apmsocketpath
+        {{ end }}
         {{ if .Values.cloudsql.enabled }}
         - name: "sidecar-volume-{{ include "docker-template.fullname" . }}"
           secret:

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -68,6 +68,9 @@ autoscaling:
       type: Pods
       value: 1
 
+datadogSocketVolume:
+  enabled: false
+
 keda:
   enabled: false
   pollingInterval: 30


### PR DESCRIPTION
This PR adds support for ensuring that apps can be configured to mount a Datadog UDS as a volume, for sending traces/APM.