### PR TITLE
Datadog UDS: Removed env var

### DIFF
--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -330,10 +330,6 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             {{ end }}
-            {{ if .Values.datadogSocketVolume.enabled }}
-            - name: DD_TRACE_AGENT_URL
-              value: "unix:///var/run/datadog/dsd.socket"
-            {{ end }}
             {{- range $syncedEnv := .Values.container.env.synced }}
             {{- range $key := $syncedEnv.keys }}
             - name: {{ $key.name }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -285,10 +285,6 @@ spec:
               value: {{ quote $val }}
             {{- end }}
             {{- end }}
-            {{ if .Values.datadogSocketVolume.enabled }}
-            - name: DD_TRACE_AGENT_URL
-              value: "unix:///var/run/datadog/dsd.socket"
-            {{ end }}
             {{- range $syncedEnv := .Values.container.env.synced }}
             {{- range $key := $syncedEnv.keys }}
             - name: {{ $key.name }}


### PR DESCRIPTION
Removed the DD_TRACE_AGENT_URL env var which was being injected earlier for DD sockets.