### PR TITLE
Datadog UDS Sockets

### DIFF
--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -358,8 +358,10 @@ spec:
             {{- end }}
         {{ if .Values.datadogSocketVolume.enabled }}
           volumeMounts:
-            - name: apmsocketpath
-              mountPath: /var/run/datadog
+            - name: datadog-apm-socket
+              mountPath: /var/run/datadog/apm.socket
+            - name: datadog-dsd-socket
+              mountPath: /var/run/datadog/dsd.socket
         {{ end }}
         {{ if .Values.awsEfsStorage }}
           volumeMounts:
@@ -454,8 +456,13 @@ spec:
       volumes:
         {{ if .Values.datadogSocketVolume.enabled }}
         - hostPath:
-            path: /var/run/datadog/
-          name: apmsocketpath
+            path: /var/run/datadog/apm.socket
+            type: Socket
+          name: datadog-apm-socket
+        - hostPath:
+            path: /var/run/datadog/dsd.socket
+            type: Socket
+          name: datadog-dsd-socket
         {{ end }}
         {{ if .Values.cloudsql.enabled }}
         - name: "sidecar-volume-{{ include "docker-template.fullname" . }}"

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -302,9 +302,11 @@ spec:
             {{- end }}
           {{ if .Values.datadogSocketVolume.enabled }}
           volumeMounts:
-            - name: apmsocketpath
-              mountPath: /var/run/datadog
-        {{ end }}
+            - name: datadog-apm-socket
+              mountPath: /var/run/datadog/apm.socket
+            - name: datadog-dsd-socket
+              mountPath: /var/run/datadog/dsd.socket
+          {{ end }}
           {{ if .Values.pvc.enabled }}
           volumeMounts:
             - name: "{{ include "docker-template.fullname" . }}-storage"
@@ -379,8 +381,13 @@ spec:
       volumes:
         {{ if .Values.datadogSocketVolume.enabled }}
         - hostPath:
-            path: /var/run/datadog/
-          name: apmsocketpath
+            path: /var/run/datadog/apm.socket
+            type: Socket
+          name: datadog-apm-socket
+        - hostPath:
+            path: /var/run/datadog/dsd.socket
+            type: Socket
+          name: datadog-dsd-socket
         {{ end }}
         {{ if .Values.cloudsql.enabled }}
         - name: "sidecar-volume-{{ include "docker-template.fullname" . }}"


### PR DESCRIPTION
Switched to mounting Datadog's UDS sockets separately, as opposed to mounting `/var/run/datadog/`.