### PR TITLE
fix: remove use of datadog.enabled for init containers

### DIFF
--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -89,20 +89,19 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.image.imagePullSecret }}
       {{- end }}
-      {{ if .Values.datadog.enabled }}
       initContainers:
+        # this is used for ensuring the kubelet is ready on new nodes, and can injected any downward API keys
         - name: downward-api
           env:
           - name: DOWNWARD_API_ENV_KEY
-            value: DD_AGENT_HOST
-          - name: DD_AGENT_HOST
+            value: DOWNWARD_HOST_IP
+          - name: DOWNWARD_HOST_IP
             valueFrom:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
           image: ghcr.io/porter-dev/downward-api-init:latest
           imagePullPolicy: Always
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -66,6 +66,19 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.image.imagePullSecret }}
       {{- end }}
+      initContainers:
+        # this is used for ensuring the kubelet is ready on new nodes, and can injected any downward API keys
+        - name: downward-api
+          env:
+          - name: DOWNWARD_API_ENV_KEY
+            value: DOWNWARD_HOST_IP
+          - name: DOWNWARD_HOST_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          image: ghcr.io/porter-dev/downward-api-init:latest
+          imagePullPolicy: Always
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
datadog.enabled doesnt seem to be used anywhere