### PR TITLE
fix: connections templating for cloud sql proxy

### DIFF
--- a/applications/job/templates/_helpers.tpl
+++ b/applications/job/templates/_helpers.tpl
@@ -75,3 +75,31 @@ Name of the service account json secret to use with the CloudSQL proxy
 {{- define "cloudsql.serviceAccountJSONSecret" -}}
 {{- default (printf "cloudsql-secret-%s" (include "docker-template.fullname" .)) .Values.cloudsql.serviceAccountJSONSecret }}
 {{- end }}
+
+{{/* 
+The connection string to be passed to the CloudSQL proxy.
+For backwards compatibility, this concatenates targets from cloudsql.connectionName/dbPort, cloudsql.additionalConnection.connectionName/dbPort in addition to the cloudsql.connections list
+*/}}
+{{- define "cloudsql.connectionString" -}}
+{{- $singleConnection := .Values.cloudsql.connectionName -}}
+{{- $additionalConnection := .Values.cloudsql.additionalConnection -}}
+{{- $connections := default (list) .Values.cloudsql.connections -}}
+{{- $hasConnections := or $singleConnection (gt (len $connections) 0) $additionalConnection.enabled -}}
+{{- if $hasConnections -}}
+    
+    {{- if $singleConnection -}}
+        {{- $singleConnection -}}=tcp:{{.Values.cloudsql.dbPort }}
+    {{- end -}}
+
+    {{- if $additionalConnection.enabled -}}
+        {{- if $singleConnection }},{{ end -}}
+        {{ $additionalConnection.connectionName }}=tcp:{{ $additionalConnection.dbPort }}
+    {{- end -}}
+
+    {{- range $index, $conn := $connections -}} 
+        {{- if or $index $singleConnection $additionalConnection.enabled }},{{ end -}}
+        {{ $conn.name }}=tcp:{{ $conn.port }}
+    {{- end -}}
+
+{{- end }}
+{{- end }}

--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -207,7 +207,7 @@ spec:
               image: gcr.io/cloudsql-docker/gce-proxy:1.17
               command:
                 - "/cloud_sql_proxy"
-                - "-instances={{ .Values.cloudsql.connectionName }}=tcp:{{ .Values.cloudsql.dbPort }}"
+                - "-instances={{- include "cloudsql.connectionString" . -}}"
                 - "-credential_file=/secrets/service_account.json"
               {{ if .Values.terminationGracePeriodSeconds }}
                 - "-term_timeout={{ .Values.terminationGracePeriodSeconds }}s"

--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -192,7 +192,7 @@ data:
             image: gcr.io/cloudsql-docker/gce-proxy:1.17
             command:
               - "/cloud_sql_proxy"
-              - "-instances={{ .Values.cloudsql.connectionName }}=tcp:{{ .Values.cloudsql.dbPort }}"
+              - "-instances={{- include "cloudsql.connectionString" . -}}"
               - "-credential_file=/secrets/service_account.json"
               {{ if .Values.terminationGracePeriodSeconds }}
               - "-term_timeout={{ .Values.terminationGracePeriodSeconds }}s"

--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -50,10 +50,17 @@ paused: false
 
 cloudsql:
   enabled: false
-  connectionName: ""
+  connections: []
+    # - name: "abcdedfg"
+    #   port: 34343
+  connectionName: "" # deprecated, keeping for backwards compatibility. use connections instead.
   dbPort: 5432
   serviceAccountJSON: ""
   serviceAccountJSONSecret: ""
+  additionalConnection: # deprecated, keeping for backwards compatibility. use connections instead. 
+    enabled: false
+    dbPort: 5432
+    connectionName: ""
 
 # Set this for enabling DNS extensions over TCP
 # We enable this by default.

--- a/applications/web/templates/_helpers.tpl
+++ b/applications/web/templates/_helpers.tpl
@@ -75,3 +75,32 @@ Name of the service account json secret to use with the CloudSQL proxy
 {{- define "cloudsql.serviceAccountJSONSecret" -}}
 {{- default (printf "cloudsql-secret-%s" (include "docker-template.fullname" .)) .Values.cloudsql.serviceAccountJSONSecret }}
 {{- end }}
+
+
+{{/* 
+The connection string to be passed to the CloudSQL proxy.
+For backwards compatibility, this concatenates targets from cloudsql.connectionName/dbPort, cloudsql.additionalConnection.connectionName/dbPort in addition to the cloudsql.connections list
+*/}}
+{{- define "cloudsql.connectionString" -}}
+{{- $singleConnection := .Values.cloudsql.connectionName -}}
+{{- $additionalConnection := .Values.cloudsql.additionalConnection -}}
+{{- $connections := default (list) .Values.cloudsql.connections -}}
+{{- $hasConnections := or $singleConnection (gt (len $connections) 0) $additionalConnection.enabled -}}
+{{- if $hasConnections -}}
+    
+    {{- if $singleConnection -}}
+        {{- $singleConnection -}}=tcp:{{.Values.cloudsql.dbPort }}
+    {{- end -}}
+
+    {{- if $additionalConnection.enabled -}}
+        {{- if $singleConnection }},{{ end -}}
+        {{ $additionalConnection.connectionName }}=tcp:{{ $additionalConnection.dbPort }}
+    {{- end -}}
+
+    {{- range $index, $conn := $connections -}} 
+        {{- if or $index $singleConnection $additionalConnection.enabled }},{{ end -}}
+        {{ $conn.name }}=tcp:{{ $conn.port }}
+    {{- end -}}
+
+{{- end }}
+{{- end }}

--- a/applications/web/templates/deployment-blue-green-legacy.yaml
+++ b/applications/web/templates/deployment-blue-green-legacy.yaml
@@ -241,7 +241,7 @@ spec:
           image: gcr.io/cloudsql-docker/gce-proxy:1.17
           command:
             - "/cloud_sql_proxy"
-            - "-instances={{ $.Values.cloudsql.connectionName }}=tcp:{{ $.Values.cloudsql.dbPort }}"
+            - "-instances={{- include "cloudsql.connectionString" . -}}"
             - "-credential_file=/secrets/service_account.json"
             {{ if $.Values.terminationGracePeriodSeconds }}
             - "-term_timeout={{ $.Values.terminationGracePeriodSeconds }}s"

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -406,11 +406,7 @@ spec:
           image: gcr.io/cloudsql-docker/gce-proxy:1.17
           command:
             - "/cloud_sql_proxy"
-            {{- if .Values.cloudsql.additionalConnection.enabled }}
-            - "-instances={{ .Values.cloudsql.connectionName }}=tcp:{{ .Values.cloudsql.dbPort }},{{ .Values.cloudsql.additionalConnection.connectionName }}=tcp:{{ .Values.cloudsql.additionalConnection.dbPort }}"
-            {{- else }}
-            - "-instances={{ .Values.cloudsql.connectionName }}=tcp:{{ .Values.cloudsql.dbPort }}"
-            {{- end }}
+            - "-instances={{- include "cloudsql.connectionString" . -}}"
             - "-credential_file=/secrets/service_account.json"
             {{ if .Values.terminationGracePeriodSeconds }}
             - "-term_timeout={{ .Values.terminationGracePeriodSeconds }}s"

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -232,11 +232,14 @@ pvc:
 
 cloudsql:
   enabled: false
-  connectionName: ""
+  connections: []
+    # - name: "abcdedfg"
+    #   port: 34343
+  connectionName: "" # deprecated, keeping for backwards compatibility. use connections instead.
   dbPort: 5432
   serviceAccountJSON: ""
   serviceAccountJSONSecret: ""
-  additionalConnection:
+  additionalConnection: # deprecated, keeping for backwards compatibility. use connections instead. 
     enabled: false
     dbPort: 5432
     connectionName: ""

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -326,7 +326,7 @@ spec:
           image: gcr.io/cloudsql-docker/gce-proxy:1.17
           command:
             - "/cloud_sql_proxy"
-            - "-instances={{ .Values.cloudsql.connectionName }}=tcp:{{ .Values.cloudsql.dbPort }}"
+            - "-instances={{- include "cloudsql.connectionString" . -}}"
             - "-credential_file=/secrets/service_account.json"
             {{ if .Values.terminationGracePeriodSeconds }}
             - "-term_timeout={{ .Values.terminationGracePeriodSeconds }}s"

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -133,10 +133,17 @@ pvc:
 
 cloudsql:
   enabled: false
-  connectionName: ""
+  connections: []
+    # - name: "abcdedfg"
+    #   port: 34343
+  connectionName: "" # deprecated, keeping for backwards compatibility. use connections instead.
   dbPort: 5432
   serviceAccountJSON: ""
   serviceAccountJSONSecret: ""
+  additionalConnection: # deprecated, keeping for backwards compatibility. use connections instead. 
+    enabled: false
+    dbPort: 5432
+    connectionName: ""
 
 # Set this to add entries to the /etc/hosts file
 # Format: hostAliases: [{ip: <IP>, hostnames: [<HOSTNAME>,..]},..]


### PR DESCRIPTION
Previously, our CloudSQL side container templating allowed at most two instances. In this change, we allow an arbitrary number of connections. It is also backwards compatible to previous values. 