### PR TITLE
feat: inject filesystem names into helm charts

### DIFF
--- a/applications/testdata/web.yaml
+++ b/applications/testdata/web.yaml
@@ -12,6 +12,8 @@ cloudsql:
   dbPort: 0
   enabled: false
   serviceAccountJSONSecret: ""
+awsEfsStorage:
+- fileSystemId: fs-0cc6c01ae6d9726e8
 configMapRefs:
 - 18-aaaaaa.1
 container:

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -313,6 +313,12 @@ spec:
                   fieldPath: status.podIP
             - name: PORTER_POD_IMAGE_TAG
               value: "{{ .Values.image.tag }}"
+            {{- if .Values.awsEfsStorage }}
+            {{- range .Values.awsEfsStorage }}
+            - name: PORTER_EFS_FILESYSTEM_ID_{{ upper $.Release.Name }}
+              value: {{ .fileSystemId }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.global }}
             {{- if .Values.global.image }}
             {{- if .Values.global.image.tag }}


### PR DESCRIPTION
Add the filesystem id to the porter app. Currently hardcoded to 1 fs ID until we inject fs names also