### PR TITLE
fix: Change image pull policy to IfNotPresent

### DIFF
--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -11,7 +11,7 @@ allowConcurrency: true
 
 image:
   repository: public.ecr.aws/o1j4x7p4/hello-porter-job
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: latest
   # A single imagePullSecret that will be injected into the deployment; only use in extreme cases, else it must be left blank. 

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
                 apiVersion: v1
                 fieldPath: status.hostIP
           image: ghcr.io/porter-dev/downward-api-init:latest
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -19,7 +19,7 @@ terminationGracePeriodSeconds: 30
 
 image:
   repository: public.ecr.aws/o1j4x7p4/hello-porter
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: latest
   # A single imagePullSecret that will be injected into the deployment; only use in extreme cases, else it must be left blank. 

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
                 apiVersion: v1
                 fieldPath: status.hostIP
           image: ghcr.io/porter-dev/downward-api-init:latest
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -17,7 +17,7 @@ terminationGracePeriodSeconds: 30
 
 image:
   repository: public.ecr.aws/o1j4x7p4/hello-porter
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: latest
   # A single imagePullSecret that will be injected into the deployment; only use in extreme cases, else it must be left blank. 


### PR DESCRIPTION
This change is because Nooks appear to be rate limited when pulling the images due to the large number of pods in their cluster. This issue was seen happening more frequently in the downward API image, which has a pull policy of `Always`