### PR TITLE
chore: set billing measurement default to 5m

### DIFF
--- a/addons/porter-agent/Chart.yaml
+++ b/addons/porter-agent/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.38.0
+version: 0.39.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/addons/porter-agent/templates/configmap.yaml
+++ b/addons/porter-agent/templates/configmap.yaml
@@ -16,3 +16,4 @@ data:
   SQL_LITE: "true"
   SQL_LITE_PATH: "/porter/sqlite/agent.db"
   PROMETHEUS_URL: "{{ .Values.agent.prometheusURL }}"
+  MEASUREMENT_PERIOD: "{{ .Values.agent.billingMeasurementPeriod }}"

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -12,6 +12,7 @@ agent:
   lokiURL: porter-agent-loki.porter-agent-system:9095
   lokiHTTPURL: http://porter-agent-loki.porter-agent-system:3100
   prometheusURL: http://prometheus-server.monitoring.svc
+  billingMeasurementPeriod: "5m"
 
 resources:
   limits:


### PR DESCRIPTION
This PR changes the default measurement period for billing events to reduce the events sent to Lago.