### PR TITLE
chore: update tailscale version to v1.72.1

### DIFF
--- a/addons/tailscale-relay/Chart.yaml
+++ b/addons/tailscale-relay/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tailscale-relay
 icon: https://images.crunchbase.com/image/upload/c_lpad,h_170,w_170,f_auto,b_white,q_auto:eco,dpr_1/xkthebhmilwbyffilnfl
 version: 0.17.0
-appVersion: v1.62.0
+appVersion: v1.72.1
 keywords:
   - APP
   - NETWORKING

--- a/addons/tailscale-relay/values.yaml
+++ b/addons/tailscale-relay/values.yaml
@@ -2,7 +2,7 @@
 replicas: 1
 
 image:
-  repository: docker.io/mvisonneau/tailscale
+  repository: docker.io/yosefmih/tailscale
   pullPolicy: IfNotPresent
   # tag: <default to chart app version>
 


### PR DESCRIPTION
The tailscale release v1.72.1 contains a security patch. The helm chart and docker image we rely on for out tailscale deployments hasn't been updated to this version. In the meantime, this PR will switch to an image that is updated. 