### PR TITLE
fix: loki log retention

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -81,6 +81,7 @@ local_resource(
   helm cm-push addons/prometheus-adapter local && \
   helm cm-push addons/langfuse local && \
   helm cm-push addons/grafana local && \
+  helm cm-push addons/porter-agent local && \
   helm repo update local
   ''',
   deps=[

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -32,18 +32,18 @@ loki:
       replication_factor: 1
     storage:
       type: filesystem
+    compactor:
+      retention_enabled: true
+      retention_delete_delay: 0h
+      retention_delete_worker_count: 50
+    limits_config:
+      reject_old_samples: true
+      # reject samples older than one week
+      reject_old_samples_max_age: 168h
+      max_concurrent_tail_requests: 50
+      # delete logs after a week
+      retention_period: 168h
   enabled: true
-  compactor:
-    retention_enabled: true
-    retention_delete_delay: 0h
-    retention_delete_worker_count: 50
-  limits_config:
-    reject_old_samples: true
-    # reject samples older than one week
-    reject_old_samples_max_age: 168h
-    max_concurrent_tail_requests: 50
-    # delete logs after a week
-    retention_period: 168h
   gateway:
     enabled: false
   isDefault: true

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -36,6 +36,12 @@ loki:
   compactor:
     retention_enabled: true
     retention_delete_delay: 0h
+  limits_config:
+    reject_old_samples: true
+    # reject samples older than one week
+    reject_old_samples_max_age: 168h
+    max_concurrent_tail_requests: 50
+    retention_period: 168h
   gateway:
     enabled: false
   isDefault: true
@@ -60,12 +66,6 @@ loki:
     persistence:
       enabled: true
       size: 100Gi
-  limits_config:
-    reject_old_samples: true
-    # reject samples older than one week
-    reject_old_samples_max_age: 168h
-    max_concurrent_tail_requests: 50
-    retention_period: 168h
   table_manager:
     retention_deletes_enabled: true
     retention_period: 168h

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -36,11 +36,13 @@ loki:
   compactor:
     retention_enabled: true
     retention_delete_delay: 0h
+    retention_delete_worker_count: 50
   limits_config:
     reject_old_samples: true
     # reject samples older than one week
     reject_old_samples_max_age: 168h
     max_concurrent_tail_requests: 50
+    # delete logs after a week
     retention_period: 168h
   gateway:
     enabled: false

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -43,6 +43,19 @@ loki:
       max_concurrent_tail_requests: 50
       # delete logs after a week
       retention_period: 168h
+    storage_config:
+      boltdb_shipper:
+        shared_store: filesystem
+    readinessProbe:
+      httpGet:
+        path: /ready
+        port: http-metrics
+      initialDelaySeconds: 45
+    livenessProbe:
+      httpGet:
+        path: /ready
+        port: http-metrics
+      initialDelaySeconds: 45
   enabled: true
   gateway:
     enabled: false
@@ -68,37 +81,15 @@ loki:
     persistence:
       enabled: true
       size: 100Gi
-  table_manager:
-    retention_deletes_enabled: true
-    retention_period: 168h
-  storage_config:
-    boltdb_shipper:
-      shared_store: filesystem
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1024Mi
+      requests:
+        cpu: 500m
+        memory: 1024Mi
   url: http://{{(include "loki.serviceName" .)}}:{{ .Values.loki.service.port }}
-  readinessProbe:
-    httpGet:
-      path: /ready
-      port: http-metrics
-    initialDelaySeconds: 45
-  livenessProbe:
-    httpGet:
-      path: /ready
-      port: http-metrics
-    initialDelaySeconds: 45
-  datasource:
-    jsonData: {}
-    uid: ""
-  persistence:
-    enabled: true
-    size: 100Gi
-  resources:
-    limits:
-      cpu: 500m
-      memory: 1024Mi
-    requests:
-      cpu: 500m
-      memory: 1024Mi
-
+  
 promtail:
   enabled: true
   config:


### PR DESCRIPTION
This PR sets up logs retention to a week properly. Before this, our templating for loki was wrong that we had effectively no retention configured. 