### PR TITLE
Create `PORTER_NODE_IP` env var for `web` and `worker` helm charts

### DIFF
--- a/applications/web/templates/deployment-blue-green-legacy.yaml
+++ b/applications/web/templates/deployment-blue-green-legacy.yaml
@@ -192,6 +192,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: PORTER_NODE_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
             - name: PORTER_POD_IMAGE_TAG
               value: "{{ $tag }}"
             {{- range $key, $val := $.Values.container.env.normal }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -311,6 +311,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: PORTER_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
             - name: PORTER_POD_IMAGE_TAG
               value: "{{ .Values.image.tag }}"
             {{- if .Values.awsEfsStorage }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -250,6 +250,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: PORTER_NODE_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
             - name: PORTER_POD_IMAGE_TAG
               value: "{{ .Values.image.tag }}"
             {{- if .Values.global }}


### PR DESCRIPTION
- **feat: `PORTER_NODE_IP` env var for web chart**
- **feat: `PORTER_NODE_IP` env var for worker web chart**
