### PR TITLE
Job sidecar - memory limits

### DIFF
--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -73,7 +73,7 @@ sidecar:
   resources:
     requests:
       cpu: 10m
-      memory: 10Mi
+      memory: 50Mi
 
 # Set this to add entries to the /etc/hosts file
 # Format: hostAliases: [{ip: <IP>, hostnames: [<HOSTNAME>,..]},..]


### PR DESCRIPTION
Due to a possible bug in recent containerd versions, increasing the memory limit for job sidecars to 50MB.