### PR TITLE
Update values.yaml - bumped the job sidecar's RAM limit to 100Mi

### DIFF
--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -73,7 +73,7 @@ sidecar:
   resources:
     requests:
       cpu: 10m
-      memory: 50Mi
+      memory: 100Mi
 
 # Set this to add entries to the /etc/hosts file
 # Format: hostAliases: [{ip: <IP>, hostnames: [<HOSTNAME>,..]},..]


### PR DESCRIPTION
A pre-emptive change, just to be sure we're ahead of any potential cgroup-related changes that pop up in the future.