### PR TITLE
Optional TLS for Ingress

### DIFF
--- a/applications/web/templates/multiple-wildcard-ingress.yaml
+++ b/applications/web/templates/multiple-wildcard-ingress.yaml
@@ -47,10 +47,12 @@ spec:
 {{- else }}
   ingressClassName: nginx
 {{- end }}
+  {{- if $hostDetails.tlsSecret}}
   tls:
     - hosts:
         - {{ $hostDetails.hostName | quote }}
       secretName: {{ $hostDetails.tlsSecret }}
+  {{- end }}
   rules:
       - host: {{ $hostDetails.hostName | quote }}
         http:

--- a/applications/web/templates/multiple-wildcard-ingress.yaml
+++ b/applications/web/templates/multiple-wildcard-ingress.yaml
@@ -45,7 +45,7 @@ spec:
 {{- if hasKey $.Values.multipleWildcardIngress.annotations "kubernetes.io/ingress.class" }}
   ingressClassName: {{ index $.Values.multipleWildcardIngress.annotations "kubernetes.io/ingress.class" }}
 {{- else }}
-  ingressClassName: nginx
+  ingressClassName: {{ $.Values.multipleWildcardIngress.ingressClass }}
 {{- end }}
   {{- if $hostDetails.tlsSecret}}
   tls:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -65,6 +65,7 @@ multipleWildcardIngress:
   enabled: false
   ingressClass: nginx
   # hosts contains a list of objects, each object contains a hostName and a tlsSecret
+  # Leave tlsSecret blank ONLY if you want to allow Ingress for a specific host without TLS
   hosts: []
   custom_domain: true
   rewriteCustomPathsEnabled: true


### PR DESCRIPTION
This PR modifies the templates generated via the `multipleWildcardIngress` block, in order to allow for scenarios where customers may need/want to allow Ingress for a specific custom domain _without_ TLS. 