### PR TITLE
Bumped up the Tailscale relay chart to use the latest Tailscale image.

### DIFF
--- a/addons/tailscale-relay/Chart.yaml
+++ b/addons/tailscale-relay/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tailscale-relay
 icon: https://images.crunchbase.com/image/upload/c_lpad,h_170,w_170,f_auto,b_white,q_auto:eco,dpr_1/xkthebhmilwbyffilnfl
 version: 0.17.0
-appVersion: v1.72.1
+appVersion: v1.76.6
 keywords:
   - APP
   - NETWORKING

--- a/addons/tailscale-relay/values.yaml
+++ b/addons/tailscale-relay/values.yaml
@@ -2,9 +2,9 @@
 replicas: 1
 
 image:
-  repository: docker.io/yosefmih/tailscale
+  repository: docker.io/mvisonneau/tailscale
   pullPolicy: IfNotPresent
-  # tag: <default to chart app version>
+  tag: v1.76.6
 
 # Use hostNetwork for the pod
 hostNetwork: false


### PR DESCRIPTION
This PR bumps up the Tailscale chart to use the latest available image at https://hub.docker.com/r/mvisonneau/tailscale/tags - `v1.76.6`. In addition, we've also switched from using a privately-maintained image back to the community image.