### PR TITLE
fix: configure gpu taint tolerations explicitly 

### DIFF
--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -462,7 +462,7 @@ spec:
           value: {{ $nodeGroup.id | quote }}
           effect: "NoSchedule"
       {{- end }}
-      # nvidia.com/gpu tolerations is automatically injected in EKS/GKE, but not in AKS 
+      # nvidia.com/gpu toleration is automatically injected in EKS/GKE, but not in AKS 
       # since we want to be cloud agnostic, we just add it ourselves wherever we need it
       {{- if .Values.resources.requests.nvidiaGpu}}
         - key: "nvidia.com/gpu"

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -462,6 +462,13 @@ spec:
           value: {{ $nodeGroup.id | quote }}
           effect: "NoSchedule"
       {{- end }}
+      # nvidia.com/gpu tolerations is automatically injected in EKS/GKE, but not in AKS 
+      # since we want to be cloud agnostic, we just add it ourselves wherever we need it
+      {{- if .Values.resources.requests.nvidiaGpu}}
+        - key: "nvidia.com/gpu"
+          operator: "Exists"
+          effect: "NoSchedule"
+      {{- end }}
       {{- if .Values.topology.enabled }}
       topologySpreadConstraints: 
         - maxSkew: {{ .Values.topology.maxSkew }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -375,6 +375,13 @@ spec:
           value: {{ $nodeGroup.id | quote }}
           effect: "NoSchedule"
       {{- end }}
+      # nvidia.com/gpu tolerations is automatically injected in EKS/GKE, but not in AKS 
+      # since we want to be cloud agnostic, we just add it ourselves wherever we need it
+      {{- if .Values.resources.requests.nvidiaGpu}}
+        - key: "nvidia.com/gpu"
+          operator: "Exists"
+          effect: "NoSchedule"
+      {{- end }}
       {{- if .Values.topology.enabled }}
       topologySpreadConstraints:
         - maxSkew: {{ .Values.topology.maxSkew }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -375,7 +375,7 @@ spec:
           value: {{ $nodeGroup.id | quote }}
           effect: "NoSchedule"
       {{- end }}
-      # nvidia.com/gpu tolerations is automatically injected in EKS/GKE, but not in AKS 
+      # nvidia.com/gpu toleration is automatically injected in EKS/GKE, but not in AKS 
       # since we want to be cloud agnostic, we just add it ourselves wherever we need it
       {{- if .Values.resources.requests.nvidiaGpu}}
         - key: "nvidia.com/gpu"


### PR DESCRIPTION
Currently, we rely on EKS/GKE injecting the `nvidia.com/gpu` taint tolerations. AKS does not do this and we currently use helm overrides for this. In the interest of cloud agnostically, this PR simply adds the toleration explicitly for all pods/deployments with GPU enabled. 

https://linear.app/porter/issue/POR-3125/azure-gpu-enabled-apps-properly-translated-to-helm