### PR TITLE
feat: add metric scraping config on web charts

### DIFF
--- a/applications/web/templates/deployment-blue-green-legacy.yaml
+++ b/applications/web/templates/deployment-blue-green-legacy.yaml
@@ -74,6 +74,12 @@ spec:
             - name: http
               containerPort: {{ $.Values.container.port }}
               protocol: TCP
+            {{- if and .Values.metricsScraping.enabled (ne .Values.metricsScraping.port .Values.container.port) }}
+            # if metrics scraping is enabled and the port is not the same as the container port, add a metrics port
+            - name: metrics
+              containerPort: {{ .Values.metricsScraping.port }}
+              protocol: TCP
+            {{- end }}
             {{- range $.Values.container.extraPorts }}
             - name: {{ .name }}
               containerPort: {{ .containerPort }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -168,6 +168,12 @@ spec:
             - name: http
               containerPort: {{ .Values.container.port }}
               protocol: TCP
+            {{- if and .Values.metricsScraping.enabled (ne .Values.metricsScraping.port .Values.container.port) }}
+            # if metrics scraping is enabled and the port is not the same as the container port, add a metrics port
+            - name: metrics
+              containerPort: {{ .Values.metricsScraping.port }}
+              protocol: TCP
+            {{- end }}
             {{- range .Values.container.extraPorts }}
             - name: {{ .name }}
               containerPort: {{ .containerPort }}

--- a/applications/web/templates/service.yaml
+++ b/applications/web/templates/service.yaml
@@ -8,13 +8,19 @@ metadata:
     {{- if .Values.labels }}
     {{- toYaml .Values.labels | nindent 4 }}
     {{- end }}
-  {{- if .Values.service.annotations }}
-  {{- if gt (len .Values.service.annotations) 0}}
+  {{- if or .Values.metricsScraping.enabled (and .Values.service.annotations (gt (len .Values.service.annotations) 0)) }}
   annotations:
+    {{- if .Values.metricsScraping.enabled }}
+    porter.prometheus/scrape: "true" 
+    porter.prometheus/port: {{ .Values.metricsScraping.port | quote }}
+    porter.prometheus/path: {{ .Values.metricsScraping.path | quote }}
+    porter.prometheus/scheme: "http"
+    {{- end }}
+    {{- if and .Values.service.annotations (gt (len .Values.service.annotations) 0) }}
     {{- range $k, $v := .Values.service.annotations }}
     {{ $k }}: {{ $v | quote }}
     {{- end }}
-  {{- end }}
+    {{- end }}
   {{- end }}
 spec:
   {{ if or .Values.ingress.enabled .Values.albIngress.enabled .Values.customNodePort.enabled }}
@@ -32,6 +38,13 @@ spec:
       {{- else if .Values.customNodePort.enabled }}
       nodePort: {{ .Values.customNodePort.port }}
       {{- end }}
+  {{- if and .Values.metricsScraping.enabled (ne .Values.metricsScraping.port .Values.service.port) }}
+    # add metrics scraping port if metrics scraping is enabled and the port is not the same as the service port
+    - port: {{ .Values.metricsScraping.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  {{- end }}
   {{- range .Values.service.extraPorts }}
     - port: {{ .port }}
       targetPort: {{ .targetPort }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -304,3 +304,9 @@ fileSecretMounts:
   mounts: []
 
 nodeGroups: []
+
+
+metricsScraping:
+  enabled: false
+  port: 80
+  path: "/metrics"


### PR DESCRIPTION
* When metric scraping is enabled, add the necessary annotations to the service
* If metric scraping port is different from the main port, make sure to template that port on the service/pods. 