### PR TITLE
feat: additional volumes on worker apps 

### DIFF
--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -331,6 +331,13 @@ spec:
               readOnly: true
           {{ end }}
           {{ end }}
+          {{ if .Values.additionalVolumes }}
+          {{ range .Values.additionalVolumes }}
+          volumeMounts:
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+          {{ end }}
+          {{ end }}
         {{- if .Values.cloudsql.enabled }}
         - name: cloud-sql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:1.17
@@ -398,7 +405,7 @@ spec:
               {{- end }}
           {{- end }}
       {{ end }}
-      {{ if or .Values.pvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.datadogSocketVolume.enabled .Values.fileSecretMounts.enabled }}
+      {{ if or .Values.pvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.datadogSocketVolume.enabled .Values.fileSecretMounts.enabled .Values.additionalVolumes (len .Values.additionalVolumes | gt 0) }}
       volumes:
         {{ if .Values.datadogSocketVolume.enabled }}
         - hostPath:
@@ -431,5 +438,10 @@ spec:
           secret:
             secretName: "{{ .secretName }}"
         {{ end }}
+        {{ end }}
+        {{ range .Values.additionalVolumes }}
+        - name: {{ .name }}
+          {{ .type }}:
+            {{- toYaml .volumeOptions | nindent 8 }}
         {{ end }}
       {{ end }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -332,11 +332,11 @@ spec:
           {{ end }}
           {{ end }}
           {{ if .Values.additionalVolumes }}
-          {{ range .Values.additionalVolumes }}
           volumeMounts:
+            {{- range .Values.additionalVolumes }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
-          {{ end }}
+            {{- end }}
           {{ end }}
         {{- if .Values.cloudsql.enabled }}
         - name: cloud-sql-proxy
@@ -405,7 +405,7 @@ spec:
               {{- end }}
           {{- end }}
       {{ end }}
-      {{ if or .Values.pvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.datadogSocketVolume.enabled .Values.fileSecretMounts.enabled .Values.additionalVolumes (len .Values.additionalVolumes | gt 0) }}
+      {{ if or .Values.pvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.datadogSocketVolume.enabled .Values.fileSecretMounts.enabled (and .Values.additionalVolumes (not (empty .Values.additionalVolumes))) }}
       volumes:
         {{ if .Values.datadogSocketVolume.enabled }}
         - hostPath:
@@ -439,9 +439,11 @@ spec:
             secretName: "{{ .secretName }}"
         {{ end }}
         {{ end }}
-        {{ range .Values.additionalVolumes }}
+        {{ if .Values.additionalVolumes }}
+        {{- range .Values.additionalVolumes }}
         - name: {{ .name }}
           {{ .type }}:
-            {{- toYaml .volumeOptions | nindent 8 }}
+            {{- toYaml .volumeOptions | nindent 12 }}
+        {{- end }}
         {{ end }}
       {{ end }}

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -178,3 +178,10 @@ nodeGroups: []
 fileSecretMounts:
   enabled: false
   mounts: []
+
+# set this to add additional volumes to the deployment
+additionalVolumes:
+  - name: ""
+    type: ""
+    mountPath: ""
+    volumeOptions: {}

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -181,7 +181,7 @@ fileSecretMounts:
 
 # set this to add additional volumes to the deployment
 additionalVolumes:
-  - name: ""
-    type: ""
-    mountPath: ""
-    volumeOptions: {}
+  # - name: ""
+  #   type: ""
+  #   mountPath: ""
+  #   volumeOptions: {}


### PR DESCRIPTION
Worker charts can now take additional volumes in this format 

additionalVolumes:
  - name: efs-txtest-txw
    type: persistentVolumeClaim
    mountPath: /data/efs/txtest-txw
    volumeOptions:
      claimName: efs-txtest-txw
      readOnly: false
      
 This helps unblock efs volume users until a permanent fix is put out