### PR TITLE
chore: conditionally set image pull policy depending on tag

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -84,11 +84,12 @@ spec:
             {{- if .Values.global }}
             {{- if .Values.global.image }}
               image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
+              imagePullPolicy: {{ if eq .Values.global.image.tag "latest" }}"Always"{{ else }}"IfNotPresent"{{ end }}
             {{- end }}
             {{- else }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ if eq .Values.image.tag "latest" }}"Always"{{ else }}"IfNotPresent"{{ end }}
             {{- end }}
-              imagePullPolicy: {{ .Values.image.pullPolicy }}
             {{- if .Values.global }}
             {{- if .Values.global.image }}
             {{- if and .Values.container.command (not (eq .Values.global.image.repository "public.ecr.aws/o1j4x7p4/hello-porter")) }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -112,11 +112,12 @@ spec:
           {{- if .Values.global }}
           {{- if .Values.global.image }}
           image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
+          imagePullPolicy: {{ if eq .Values.global.image.tag "latest" }}"Always"{{ else }}"IfNotPresent"{{ end }}
           {{- end }}
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ if eq .Values.image.tag "latest" }}"Always"{{ else }}"IfNotPresent"{{ end }}
           {{- end }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.global }}
           {{- if .Values.global.image }}
           {{- if and .Values.container.command (not (eq .Values.global.image.repository "public.ecr.aws/o1j4x7p4/hello-porter")) }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -89,11 +89,12 @@ spec:
           {{- if .Values.global }}
           {{- if .Values.global.image }}
           image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
+          imagePullPolicy: {{ if eq .Values.global.image.tag "latest" }}"Always"{{ else }}"IfNotPresent"{{ end }}
           {{- end }}
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ if eq .Values.image.tag "latest" }}"Always"{{ else }}"IfNotPresent"{{ end }}
           {{- end }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.global }}
           {{- if .Values.global.image }}
           {{- if and .Values.container.command (not (eq .Values.global.image.repository "public.ecr.aws/o1j4x7p4/hello-porter")) }}


### PR DESCRIPTION
This PR changes the image pull policy to default to `IfNotPresent`, unless the `latest` tag is used, in which case it will use `Always`. 

This addresses the problem of using a less agressive pull policy while retaining the ability to use the `latest` tag in a useful way.