### PR TITLE
feat: tailscale accessibilty to grafana and managed postgresql services

### DIFF
--- a/addons/grafana/templates/service.yaml
+++ b/addons/grafana/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "grafana.fullname" . }}
   namespace: {{ include "grafana.namespace" . }}
   labels:
+    porter.run/tailscale-svc: "true"
     {{- include "grafana.labels" . | nindent 4 }}
     {{- with .Values.service.labels }}
     {{- toYaml . | nindent 4 }}

--- a/addons/postgresql-managed/templates/primary/svc.yaml
+++ b/addons/postgresql-managed/templates/primary/svc.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: primary
+    porter.run/tailscale-svc: "true"
   {{- if or .Values.commonAnnotations .Values.primary.service.annotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.primary.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}


### PR DESCRIPTION
Adds the `porter.run/tailscale-svc: "true"` label to the grafana and managed postgresql services, enabling direct access via tailscale for both. 