### PR TITLE
feat: adds support for multiple wildcard ingress in the Grafana add-on

### DIFF
--- a/addons/grafana/templates/ingress.yaml
+++ b/addons/grafana/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled ( not .Values.multipleWildcardIngress.enabled ) -}}
 {{- $ingressApiIsStable := eq (include "grafana.ingress.isStable" .) "true" -}}
 {{- $ingressSupportsIngressClassName := eq (include "grafana.ingress.supportsIngressClassName" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "grafana.ingress.supportsPathType" .) "true" -}}

--- a/addons/grafana/templates/multiple-wildcard-ingress.yaml
+++ b/addons/grafana/templates/multiple-wildcard-ingress.yaml
@@ -1,0 +1,71 @@
+{{- if $.Values.multipleWildcardIngress.enabled -}}
+{{- $fullName := include "grafana.fullname" . -}}
+{{- $svcPort := $.Values.service.port -}}
+{{- range $index, $hostDetails := $.Values.multipleWildcardIngress.hosts }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "grafana.namespace" $ }}
+  labels:
+    {{- include "grafana.labels" $ | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 50m
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
+    {{- if $.Values.multipleWildcardIngress.rewriteCustomPathsEnabled }}
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    {{- end }}
+    # provider-agnostic default annotations
+    # if value is provided as "null" or null, it is unset
+    # adding a fix for scenarios where ingress annotations are inside ingress.annotations.normal
+    {{- if not (hasKey $.Values.multipleWildcardIngress.annotations "normal")}} 
+    {{- if gt (len $.Values.multipleWildcardIngress.annotations) 0}}
+    {{- range $k, $v := $.Values.multipleWildcardIngress.annotations }}
+    {{- if $v}}
+    {{- if and (not (eq $v "null")) $v}}
+    {{ $k }}: {{ $v }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- if hasKey $.Values.multipleWildcardIngress.annotations "normal"}}
+    {{- if gt (len $.Values.multipleWildcardIngress.annotations.normal) 0}}
+    {{- range $k, $v := $.Values.multipleWildcardIngress.annotations.normal }}
+    {{- if $v}}
+    {{- if and (not (eq $v "null")) $v}}
+    {{ $k }}: {{ $v }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+spec:
+  {{- if hasKey $.Values.multipleWildcardIngress.annotations "kubernetes.io/ingress.class" }}
+  ingressClassName: {{ index $.Values.multipleWildcardIngress.annotations "kubernetes.io/ingress.class" }}
+  {{- else }}
+  ingressClassName: {{ $.Values.multipleWildcardIngress.ingressClass }}
+  {{- end }}
+  {{- if $hostDetails.tlsSecret }}
+  tls:
+    - hosts:
+        - {{ $hostDetails.hostName | quote }}
+      secretName: {{ $hostDetails.tlsSecret }}
+  {{- end }}
+  rules:
+    - host: {{ $hostDetails.hostName | quote }}
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+{{- if not (eq $index (sub (len $.Values.multipleWildcardIngress.hosts) 1)) }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/addons/grafana/values.yaml
+++ b/addons/grafana/values.yaml
@@ -259,9 +259,9 @@ serviceMonitor:
   targetLabels: []
 
 extraExposePorts: []
- # - name: keycloak
- #   port: 8080
- #   targetPort: 8080
+  # - name: keycloak
+  #   port: 8080
+  #   targetPort: 8080
 
 # overrides pod.spec.hostAliases in the grafana deployment's pods
 hostAliases: []
@@ -306,6 +306,16 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+multipleWildcardIngress:
+  enabled: false
+  ingressClass: nginx
+  # hosts contains a list of objects, each object contains a hostName and a tlsSecret
+  # Leave tlsSecret blank ONLY if you want to allow Ingress for a specific host without TLS
+  hosts: []
+  custom_domain: true
+  rewriteCustomPathsEnabled: true
+  annotations: {}
 
 resources: {}
 #  limits:


### PR DESCRIPTION
Enables multiple wildcard ingress for the Grafana add-on.

Use-cases: wildcard domains and internal LBs.