### PR TITLE
fix: disable validation in the datadog admission webhook

### DIFF
--- a/addons/datadog/values.yaml
+++ b/addons/datadog/values.yaml
@@ -1084,7 +1084,7 @@ clusterAgent:
     # clusterAgent.admissionController.validation -- Validation Webhook configuration options
     validation:
       # clusterAgent.admissionController.validation.enabled -- Enabled enables the Admission Controller validation webhook. Default: true. (Requires Agent 7.59.0+).
-      enabled: true
+      enabled: false
 
     # clusterAgent.admissionController.mutation -- Mutation Webhook configuration options
     mutation:


### PR DESCRIPTION
The datadog admission webhook is responsible for injecting variables like DD_AGENT_HOST into workload pods. Right now it is set to validate before mutating. That was blocking injection. This change disables validation. 