### PR TITLE
Fix: deploy DD add-on node agents to any nodes

### DIFF
--- a/addons/datadog/templates/daemonset.yaml
+++ b/addons/datadog/templates/daemonset.yaml
@@ -182,6 +182,9 @@ spec:
 {{ toYaml .Values.agents.volumes | indent 6 }}
 {{- end }}
       tolerations:
+      - effect: NoSchedule
+        key: porter.run/node-group-id
+        operator: Exists
       {{- if eq .Values.targetSystem "windows" }}
       - effect: NoSchedule
         key: node.kubernetes.io/os

--- a/addons/datadog/templates/daemonset.yaml
+++ b/addons/datadog/templates/daemonset.yaml
@@ -185,6 +185,9 @@ spec:
       - effect: NoSchedule
         key: porter.run/node-group-id
         operator: Exists
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
       {{- if eq .Values.targetSystem "windows" }}
       - effect: NoSchedule
         key: node.kubernetes.io/os


### PR DESCRIPTION
Currently, DD node agents aren't deployed to custom node groups. This toleration solves it.