### PR TITLE
fix: reduce memory request for hf llm addons

### DIFF
--- a/addons/hf-llm-models/values.yaml
+++ b/addons/hf-llm-models/values.yaml
@@ -37,7 +37,7 @@ readinessProbe:
 resources:
   requests:
     cpu: 2
-    memory: 14000Mi
+    memory: 12000Mi
     nvidiaGpu: "1"
   limits:
     cpu: 4


### PR DESCRIPTION
This was causing failures due to pending pods due to the memory request being too high. 