### PR TITLE
increase dshm by default for gpu nodes

### DIFF
--- a/applications/testdata/web.yaml
+++ b/applications/testdata/web.yaml
@@ -94,6 +94,7 @@ resources:
   requests:
     cpu: "0.2"
     memory: 100M
+    nvidiaGpu: 2
 secretRefs:
 - 18-aaaaaa.1
 service:

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -400,6 +400,11 @@ spec:
             - name: datadog-dsd-socket
               mountPath: /var/run/datadog/dsd.socket
         {{ end }}
+        {{ if .Values.resources.requests.nvidiaGpu}}
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+        {{ end }}
         {{ if .Values.awsEfsStorage }}
           volumeMounts:
         {{- range $v := .Values.awsEfsStorage }}
@@ -492,7 +497,7 @@ spec:
               {{- end }}
           {{- end }}
       {{ end }}
-      {{ if or .Values.pvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.fileSecretMounts.enabled .Values.awsEfsStorage .Values.datadogSocketVolume.enabled }}
+      {{ if or .Values.pvc.enabled .Values.resources.requests.nvidiaGpu .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.fileSecretMounts.enabled .Values.awsEfsStorage .Values.datadogSocketVolume.enabled }}
       volumes:
         {{ if .Values.datadogSocketVolume.enabled }}
         - hostPath:
@@ -503,6 +508,12 @@ spec:
             path: /var/run/datadog/dsd.socket
             type: Socket
           name: datadog-dsd-socket
+        {{ end }}
+        {{ if .Values.resources.requests.nvidiaGpu}}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 4Gi
         {{ end }}
         {{ if .Values.cloudsql.enabled }}
         - name: "sidecar-volume-{{ include "docker-template.fullname" . }}"


### PR DESCRIPTION
most models needs a higher dshm. This increases the default from 64m to 4g