### PR TITLE
Fix deployment-blue-green-legacy.yaml again

### DIFF
--- a/applications/web/templates/deployment-blue-green-legacy.yaml
+++ b/applications/web/templates/deployment-blue-green-legacy.yaml
@@ -74,10 +74,10 @@ spec:
             - name: http
               containerPort: {{ $.Values.container.port }}
               protocol: TCP
-            {{- if and .Values.metricsScraping.enabled (ne .Values.metricsScraping.port .Values.container.port) }}
+            {{- if and $.Values.metricsScraping.enabled (ne $.Values.metricsScraping.port $.Values.container.port) }}
             # if metrics scraping is enabled and the port is not the same as the container port, add a metrics port
             - name: metrics
-              containerPort: {{ .Values.metricsScraping.port }}
+              containerPort: {{ $.Values.metricsScraping.port }}
               protocol: TCP
             {{- end }}
             {{- range $.Values.container.extraPorts }}


### PR DESCRIPTION
`template: web/templates/deployment-blue-green-legacy.yaml:77:30: executing "web/templates/deployment-blue-green-legacy.yaml" at <.Values.metricsScraping.enabled>: can't evaluate field Values in type interface {}`

* #1200
* #1219