### PR TITLE
Allow setting the prometheus scaler ignoreNullValues option

### DIFF
--- a/applications/web/templates/scaled-object-blue-green.yaml
+++ b/applications/web/templates/scaled-object-blue-green.yaml
@@ -50,6 +50,7 @@ spec:
         metricName: {{ $.Values.keda.trigger.metricName }}
         query: {{ $.Values.keda.trigger.metricQuery }}
         threshold: '{{ $.Values.keda.trigger.metricThreshold }}'
+        ignoreNullValues: {{ $.Values.keda.trigger.ignoreNullValues | default "true" | quote }}
   {{- end }}
   {{- if $.Values.keda.triggers }}
   triggers:

--- a/applications/web/templates/scaled-object.yaml
+++ b/applications/web/templates/scaled-object.yaml
@@ -41,6 +41,7 @@ spec:
         metricName: {{ .Values.keda.trigger.metricName }}
         query: {{ .Values.keda.trigger.metricQuery }}
         threshold: '{{ .Values.keda.trigger.metricThreshold }}'
+        ignoreNullValues: {{ .Values.keda.trigger.ignoreNullValues | default "true" | quote }}
   {{- end }}
   {{- if .Values.keda.triggers }}
   triggers:

--- a/applications/worker/templates/scaled-object.yaml
+++ b/applications/worker/templates/scaled-object.yaml
@@ -42,6 +42,7 @@ spec:
         metricName: {{ .Values.keda.trigger.metricName }}
         query: {{ .Values.keda.trigger.metricQuery }}
         threshold: '{{ .Values.keda.trigger.metricThreshold }}'
+        ignoreNullValues: {{ .Values.keda.trigger.ignoreNullValues | default "true" | quote }}
   {{- end }}
   {{- if .Values.keda.triggers }}
   triggers:


### PR DESCRIPTION
The KEDA prometheus scaler has an option `ignoreNullValues` that defaults to true. In this configuration if prometheus returns an empty value then KEDA ignores it and treats it as a 0. This pretty much prevents any scaling from happening.

By setting `ignoreNullValues` to false, KEDA will treat the empty response as an error and scale to the fallback.replicas amount.

https://keda.sh/docs/2.12/scalers/prometheus/