### PR TITLE
chore: bump porter agent to 3.5.0

### DIFF
--- a/addons/porter-agent/Chart.yaml
+++ b/addons/porter-agent/Chart.yaml
@@ -18,7 +18,7 @@ version: 0.50.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.4.9"
+appVersion: "3.5.0"
 dependencies:
   - name: "loki"
     repository: "https://chart-addons.getporter.dev"

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -1,5 +1,5 @@
 agent:
-  image: "ghcr.io/porter-dev/releases/porter-agent:3.4.9"
+  image: "ghcr.io/porter-dev/releases/porter-agent:3.5.0"
   cfAccessToken: ""
   porterHost: "dashboard.porter.run"
   porterPort: "80"


### PR DESCRIPTION
bump porter agent to 3.5.0