### PR TITLE
chore: allow specifying mount paths

### DIFF
--- a/applications/web/templates/_helpers.tpl
+++ b/applications/web/templates/_helpers.tpl
@@ -104,3 +104,15 @@ For backwards compatibility, this concatenates targets from cloudsql.connectionN
 
 {{- end }}
 {{- end }}
+
+{{/*
+Get the EFS mount path for a given volume. If an override is provided, use that.
+Otherwise, use the default path /data/efs/<fullname>
+*/}}
+{{- define "docker-template.efsMountPath" -}}
+{{- if .mountPath -}}
+{{- .mountPath -}}
+{{- else -}}
+{{- printf "/data/efs/%s" .fullname -}}
+{{- end -}}
+{{- end -}}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -412,7 +412,7 @@ spec:
           volumeMounts:
         {{- range $v := .Values.awsEfsStorage }}
           - name: efs-{{ $.Values.fullnameOverride }}
-            mountPath: /data/efs/{{ $.Values.fullnameOverride }}
+            mountPath: {{ include "docker-template.efsMountPath" (dict "mountPath" $v.mountPath "fullname" $.Values.fullnameOverride) }}
         {{ end }}   
         {{ end }}  
           {{ if .Values.pvc.enabled }}


### PR DESCRIPTION
When efs volume IDs are passed, right now we default to a mount path at `data/efs/[app-name-service-name]`. This PR allows passing an optional mount path. 