### PR TITLE
chore: allow configuring custom directory perms on the efs volumes

### DIFF
--- a/applications/web/templates/efs-storage-class.yaml
+++ b/applications/web/templates/efs-storage-class.yaml
@@ -8,7 +8,7 @@ provisioner: efs.csi.aws.com
 parameters:
   provisioningMode: efs-ap
   fileSystemId: {{ $v.fileSystemId }}
-  directoryPerms: {{ default "700" $v.directoryPerms }}
+  directoryPerms: "{{ default "700" $v.directoryPerms }}"
   reuseAccessPoint: "true"
 ---
 apiVersion: v1

--- a/applications/web/templates/efs-storage-class.yaml
+++ b/applications/web/templates/efs-storage-class.yaml
@@ -8,7 +8,7 @@ provisioner: efs.csi.aws.com
 parameters:
   provisioningMode: efs-ap
   fileSystemId: {{ $v.fileSystemId }}
-  directoryPerms: "700"
+  directoryPerms: {{ default "700" $v.directoryPerms }}
   reuseAccessPoint: "true"
 ---
 apiVersion: v1

--- a/applications/web/templates/efs-storage-class.yaml
+++ b/applications/web/templates/efs-storage-class.yaml
@@ -21,7 +21,7 @@ spec:
   storageClassName: {{ include "docker-template.efsName" (dict "fullname" $.Values.fullnameOverride "index" $index) }}
   resources:
     requests:
-      storage: 5Gi
+      storage: {{ default "5Gi" $v.storageSize }}
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
We used to create efs volumes for Porter apps with perm 700. We have a use case from a customer that requires more permissive permissions. This PR modifies the helm chart to support specifying the required perm. 