### PR TITLE
chore: bump porter agent to 3.5.1

### DIFF
--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -1,5 +1,5 @@
 agent:
-  image: "ghcr.io/porter-dev/releases/porter-agent:3.5.0"
+  image: "ghcr.io/porter-dev/releases/porter-agent:3.5.1"
   cfAccessToken: ""
   porterHost: "dashboard.porter.run"
   porterPort: "80"

--- a/addons/porter-agent/values.yaml
+++ b/addons/porter-agent/values.yaml
@@ -1,5 +1,5 @@
 agent:
-  image: "ghcr.io/porter-dev/releases/porter-agent:3.5.1"
+  image: "ghcr.io/porter-dev/releases/porter-agent:3.5.2"
   cfAccessToken: ""
   porterHost: "dashboard.porter.run"
   porterPort: "80"


### PR DESCRIPTION
Bumping to a version with more accurate app event detection