### PR TITLE
feat: adds an additional volumes field to the web charts

### DIFF
--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -433,6 +433,13 @@ spec:
               readOnly: true
           {{ end }}
           {{ end }}
+          {{ if .Values.additionalVolumes }}
+          volumeMounts:
+            {{- range .Values.additionalVolumes }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
+          {{ end }}
         {{- if .Values.cloudsql.enabled }}
         - name: cloud-sql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:1.17
@@ -500,7 +507,7 @@ spec:
               {{- end }}
           {{- end }}
       {{ end }}
-      {{ if or .Values.pvc.enabled .Values.resources.requests.nvidiaGpu .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.fileSecretMounts.enabled .Values.awsEfsStorage .Values.datadogSocketVolume.enabled }}
+      {{ if or .Values.pvc.enabled .Values.resources.requests.nvidiaGpu .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.fileSecretMounts.enabled .Values.awsEfsStorage .Values.datadogSocketVolume.enabled (and .Values.additionalVolumes (not (empty .Values.additionalVolumes))) }}
       volumes:
         {{ if .Values.datadogSocketVolume.enabled }}
         - hostPath:
@@ -550,6 +557,13 @@ spec:
           secret:
             secretName: "{{ .secretName }}"
         {{ end }}
+        {{ end }}
+        {{ if .Values.additionalVolumes }}
+        {{- range .Values.additionalVolumes }}
+        - name: {{ .name }}
+          {{ .type }}:
+            {{- toYaml .volumeOptions | nindent 12 }}
+        {{- end }}
         {{ end }}
       {{ end }}
 {{- end }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -234,6 +234,13 @@ pvc:
   mountPath: /mypath
   existingVolume: ""
 
+# set this to add additional volumes to the deployment
+additionalVolumes:
+  # - name: ""
+  #   type: ""
+  #   mountPath: ""
+  #   volumeOptions: {}
+
 cloudsql:
   enabled: false
   connections: []
@@ -315,3 +322,4 @@ metricsScraping:
 # this is the case for instance for pods that need to use the MPS sliced GPUs
 # enable this conservatively
 enableHostIpc: false
+


### PR DESCRIPTION
We already have this field on the worker charts. Adding it on web charts enables mounting externally provisioned volumes (like persistent disks) to be mounted on a web service. 