### PR TITLE
fix: allow not rewriting custom paths and setting use regex

### DIFF
--- a/applications/web/templates/ingress.yaml
+++ b/applications/web/templates/ingress.yaml
@@ -14,12 +14,11 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
-    {{- if gt (len $customPaths) 0 }}
-    {{- if .Values.ingress.rewriteCustomPathsEnabled}}
+    {{- if and (gt (len $customPaths) 0) .Values.ingress.rewriteCustomPathsEnabled }}
     nginx.ingress.kubernetes.io/rewrite-target: /
-    {{- else }}
-    nginx.ingress.kubernetes.io/use-regex: "true"
     {{- end }}
+    {{- if .Values.ingress.useRegex }}
+    nginx.ingress.kubernetes.io/use-regex: "true"
     {{- end }}
     {{- if .Values.ingress.tls }}
     {{- if not (hasKey .Values.ingress.annotations "cert-manager.io/cluster-issuer")}}


### PR DESCRIPTION
Allow setting use-regex to true for nginx ingress