### PR TITLE
feat: add the blue green group name to the rollout object when group based bg is enabled

### DIFF
--- a/applications/web/templates/deployment-analysis-template.yaml
+++ b/applications/web/templates/deployment-analysis-template.yaml
@@ -29,7 +29,9 @@ spec:
                     memory: 100Mi
                 command: [sh, -c]
                 args:
-                {{- if and (.Values.deploymentStrategy.blueGreen)  (.Values.deploymentStrategy.blueGreen.partnerApps) }}
+                {{- if and (.Values.deploymentStrategy.blueGreen)  (.Values.deploymentStrategy.blueGreen.group) }}
+                - rollout sync --strategy blue-green
+                {{- else if and (.Values.deploymentStrategy.blueGreen)  (.Values.deploymentStrategy.blueGreen.partnerApps) }}
                 - rollout sync --strategy blue-green --blue-green-apps {{ range $index, $app := .Values.deploymentStrategy.blueGreen.partnerApps }}{{ if $index }},{{ end }}{{ $app }}{{ end }}
                 {{- else }}
                 - rollout sync --strategy blue-green --blue-green-apps {{ include "docker-template.fullname" . }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- toYaml .Values.labels | nindent 4 }}
     {{- end }}
     {{- if and (eq .Values.deploymentStrategy.kind "blueGreen") .Values.deploymentStrategy.blueGreen.group }}
-    porter.run/bg-group: {{ .Values.deploymentStrategy.blueGreen.group | quote }}
+    porter.run/blue-green-group: {{ .Values.deploymentStrategy.blueGreen.group | quote }}
     {{- end }}
 spec:
   {{- if and (.Values.deploymentStrategy) (eq .Values.deploymentStrategy.kind "blueGreen") }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- if .Values.labels }}
     {{- toYaml .Values.labels | nindent 4 }}
     {{- end }}
+    {{- if and (eq .Values.deploymentStrategy.kind "blueGreen") .Values.deploymentStrategy.blueGreen.group }}
+    porter.run/bg-group: {{ .Values.deploymentStrategy.blueGreen.group | quote }}
+    {{- end }}
 spec:
   {{- if and (.Values.deploymentStrategy) (eq .Values.deploymentStrategy.kind "blueGreen") }}
   strategy:


### PR DESCRIPTION
Previously, we added B/G using a `partnerApps` key in the porter app values. To move to a tag based approached which scales better, we require adding the group name as a label on the `Rollout`. 