### PR TITLE
Configuring the downward-api-init image

### DIFF
--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-          image: ghcr.io/porter-dev/downward-api-init:latest
+          image: {{ .Values.downwardAPIInit.image }}
           imagePullPolicy: IfNotPresent
       containers:
         - name: {{ .Chart.Name }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -25,6 +25,9 @@ image:
   # A single imagePullSecret that will be injected into the deployment; only use in extreme cases, else it must be left blank. 
   imagePullSecret:
 
+downwardAPIInit:
+  image: ghcr.io/porter-dev/downward-api-init:latest
+
 podLabels: {}
 
 serviceAccount:

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-          image: ghcr.io/porter-dev/downward-api-init:latest
+          image: {{ .Values.downwardAPIInit.image }}
           imagePullPolicy: IfNotPresent
       containers:
         - name: {{ .Chart.Name }}

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -23,6 +23,9 @@ image:
   # A single imagePullSecret that will be injected into the deployment; only use in extreme cases, else it must be left blank. 
   imagePullSecret:
 
+downwardAPIInit:
+  image: ghcr.io/porter-dev/downward-api-init:latest
+
 podLabels: {}
 
 serviceAccount:


### PR DESCRIPTION
Added config to chart values for web and worker apps to allow for the `downward-api-init` image to be configurable.