### PR TITLE
Metabase - image tag

### DIFF
--- a/addons/metabase/templates/deployment.yaml
+++ b/addons/metabase/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: metabase/metabase:latest
+          image: metabase/metabase:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http


### PR DESCRIPTION
Modified Metabase's deployment template to use the tag specified in the chart's values.