### PR TITLE
feat: add separate activeDeadlineSeconds templating for job charts

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -288,7 +288,9 @@ spec:
               effect: "NoSchedule"
           {{- end }}
       backoffLimit: 0
-      {{- if (.Values.sidecar.timeout) }}
+      {{- if .Values.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
+      {{- else if .Values.sidecar.timeout }}
       activeDeadlineSeconds: {{ .Values.sidecar.timeout }}
       {{- end }}
 {{ end }}

--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -104,3 +104,6 @@ fileSecretMounts:
 # this is the case for instance for pods that need to use the MPS sliced GPUs
 # enable this conservatively
 enableHostIpc: false
+
+# job timeout configuration
+activeDeadlineSeconds: # Optional - if not set, will use sidecar.timeout


### PR DESCRIPTION
Allows for decoupling how the porter job monitoring sidecar and the activeDeadlineSeconds on jobs are configured