### PR TITLE
fix: volume mounts in Cronjob

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -168,8 +168,8 @@ spec:
               {{- end }}
               {{- end }}
               {{ if and .Values.fileSecretMounts .Values.fileSecretMounts.enabled }}
-              {{ range .Values.fileSecretMounts.mounts }}
               volumeMounts:
+              {{ range .Values.fileSecretMounts.mounts }}
                 - name: {{ .mountPath }}
                   mountPath: "/etc/secrets/{{ .mountPath }}"
                   readOnly: true


### PR DESCRIPTION
Move the range section to be inside `volumeMounts`. This patches an issue where the job is producing duplicate `volumeMounts` keys, that prevents the job from using multiple env groups with files.