### PR TITLE
fix: datadog namespace exclusion filters

### DIFF
--- a/addons/datadog/values.yaml
+++ b/addons/datadog/values.yaml
@@ -339,7 +339,7 @@ datadog:
 
     ## ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
     originDetection: true
-x
+
     # datadog.dogstatsd.tags -- List of static tags to attach to every custom metric, event and service check collected by Dogstatsd.
 
     ## Learn more about tagging: https://docs.datadoghq.com/tagging/


### PR DESCRIPTION
## Description 
This PR addresses an issue where containers in namespaces with names containing substrings of excluded namespaces were being unintentionally filtered out during autodisovery.

## Problem 
The existing container exclusion rules in our datadog default values.yaml for namespaces (e.g., `kube_namespace:telemetry`) were being interpreted as regular expression substring matches. The datadog agent translates these into [CEL](https://bugsigdb.org/CEL_data_file_format) rules. This caused the datadog Agent to filter out containers from any namespace whose name included `telemetry`, such as `new-relics-telemetry`, preventing metrics and logs from being collected for those services.

## Fix 
The solution is to make the namespace matching exact by using regex anchors (^ for the start of the string and $ for the end of the string) in the exclusion rules within our Helm configuration.
This PR updates the following configurations in our Helm values.yaml:
* container_exclude
* container_exclude_logs
* container_exclude_metrics
