### PR TITLE
chore: configure main container for kubectl log/exec operations

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -39,6 +39,7 @@ spec:
       template:
         metadata:
           annotations:
+            kubectl.kubernetes.io/default-container: {{ .Chart.Name }}
             {{- if .Values.safeToEvict }}
             "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
             {{- else }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -58,6 +58,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubectl.kubernetes.io/default-container: {{ .Chart.Name }}
         helm.sh/revision: {{ .Release.Revision | quote }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
   template:
     metadata:
       annotations:
+        kubectl.kubernetes.io/default-container: {{ .Chart.Name }}
         helm.sh/revision: {{ .Release.Revision | quote }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Adds an [annotation](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubectl-kubernetes-io-default-container) with key `kubectl.kubernetes.io/default-container` and value the name of the main container to identify the main container in a Porter app. This makes it easy to run log/exec operations without specifying a `-c`. 