### PR TITLE
fix: cloud sql proxy sidecar creds volume naming

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -247,14 +247,14 @@ spec:
               securityContext:
                 runAsNonRoot: true
               volumeMounts:
-                - name: "sidecar-volume-{{ include "docker-template.fullname" . }}"
+                - name: "cloud-sql-proxy-service-account-secret"
                   mountPath: /secrets/
                   readOnly: true
           {{ end }}
           {{ if or .Values.cloudsql.enabled .Values.fileSecretMounts.enabled .Values.pvc.enabled}}
           volumes:
             {{ if .Values.cloudsql.enabled }}
-            - name: "sidecar-volume-{{ include "docker-template.fullname" . }}"
+            - name: "cloud-sql-proxy-service-account-secret"
               secret:
                 secretName: "{{ include "cloudsql.serviceAccountJSONSecret" . }}"
             {{ end }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -474,7 +474,7 @@ spec:
               memory: 128Mi
               cpu: 0.1
           volumeMounts:
-          - name: "sidecar-volume-{{ include "docker-template.fullname" . }}"
+          - name: "cloud-sql-proxy-service-account-secret"
             mountPath: /secrets/
             readOnly: true
         {{ end }}
@@ -540,7 +540,7 @@ spec:
             sizeLimit: 4Gi
         {{ end }}
         {{ if .Values.cloudsql.enabled }}
-        - name: "sidecar-volume-{{ include "docker-template.fullname" . }}"
+        - name: "cloud-sql-proxy-service-account-secret"
           secret:
             secretName: "{{ include "cloudsql.serviceAccountJSONSecret" . }}"
         {{ end }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -361,7 +361,7 @@ spec:
           securityContext:
             runAsNonRoot: true
           volumeMounts:
-          - name: "sidecar-volume-{{ include "docker-template.fullname" . }}"
+          - name: "cloud-sql-proxy-service-account-secret"
             mountPath: /secrets/
             readOnly: true
         {{ end }}
@@ -421,7 +421,7 @@ spec:
           name: datadog-dsd-socket
         {{ end }}
         {{ if .Values.cloudsql.enabled }}
-        - name: "sidecar-volume-{{ include "docker-template.fullname" . }}"
+        - name: "cloud-sql-proxy-service-account-secret"
           secret:
             secretName: "{{ include "cloudsql.serviceAccountJSONSecret" . }}"
         {{ end }}


### PR DESCRIPTION
The cloud sql proxy gets a volume mount containing service account credentials. The name we used before was verbose, leading to errors due to the length restriction on volume/volumeMount names which must be under 63 chars. 