### PR TITLE
Avoid Karpenter disruption on job's running pods

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -42,8 +42,10 @@ spec:
             kubectl.kubernetes.io/default-container: {{ .Chart.Name }}
             {{- if .Values.safeToEvict }}
             "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
+            "karpenter.sh/do-not-disrupt": "false"
             {{- else }}
             "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+            "karpenter.sh/do-not-disrupt": "true"
             {{- end }}
           labels:
             {{- if .Values.podLabels }}

--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -42,7 +42,6 @@ spec:
             kubectl.kubernetes.io/default-container: {{ .Chart.Name }}
             {{- if .Values.safeToEvict }}
             "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
-            "karpenter.sh/do-not-disrupt": "false"
             {{- else }}
             "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
             "karpenter.sh/do-not-disrupt": "true"


### PR DESCRIPTION
Currently, the job chart avoids disruptions from the classical cluster
autoscaler, but not from Karpenter. This leads jobs from users using the Cost
Optimization feature to get evicted in mid-run. This happens because Karpenter
understands that the job pod's node as underutilized and must be replaced for a
cheaper one. Then Karpenter evicts the job, which not only misses its progress,
but also can't be scheduled over due to the backoff limit.

The present solution blocks eviction by default. There is also the option to
remove this behavior via the Helm values.