### PR TITLE
New image repositories for Postgres and Redis

### DIFF
--- a/addons/postgresql-managed/values.yaml
+++ b/addons/postgresql-managed/values.yaml
@@ -97,8 +97,8 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/postgresql
-  tag: 16.1.0-debian-11-r15
+  repository: porterhub/postgresql-managed
+  tag: 16.1.0-debian-11-r16
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/addons/redis-managed/values.yaml
+++ b/addons/redis-managed/values.yaml
@@ -93,7 +93,7 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/redis
+  repository: porterhub/redis-managed
   tag: 7.2.3-debian-11-r2
   digest: ''
   ## Specify a imagePullPolicy


### PR DESCRIPTION
Thanks to the fallout from Bitnami's decision to retire upstream `bitnami` images, this PR updates image repositories for in-cluster Postgres and Redis addon charts. 

1. `postgresql-managed` now uses `docker.io/porterhub/postgresql-managed`(in the future, this can also be switched to `docker.io/porterhub/postgresql-extensions`, which is the same image but with support for `pgvector` with other potential extensions made available in the near future).
2. `redis-managed` now uses `docker.io/porterhub/redis-managed`.

The repos may be found here:
[https://hub.docker.com/repository/docker/porterhub/postgresql-managed/general](https://hub.docker.com/repository/docker/porterhub/postgresql-managed/general)
[https://hub.docker.com/repository/docker/porterhub/postgresql-extensions/general](https://hub.docker.com/repository/docker/porterhub/postgresql-extensions/general)
[https://hub.docker.com/repository/docker/porterhub/redis-managed/general](https://hub.docker.com/repository/docker/porterhub/redis-managed/general)

