### PR TITLE
Support for attaching multiple PVCs

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -182,6 +182,12 @@ spec:
                 - name: "{{ include "docker-template.fullname" . }}-storage"
                   mountPath: {{ .Values.pvc.mountPath }}
               {{ end }}
+              {{- if .Values.multiplePvc.enabled }}
+              {{- range .Values.multiplePvc.volumes }}
+              - name: {{ .name }}
+                mountPath: {{ .mountPath }}
+              {{- end }}
+              {{- end }}
               resources:
                 requests:
                   cpu: {{ .Values.resources.requests.cpu }}
@@ -252,7 +258,7 @@ spec:
                   mountPath: /secrets/
                   readOnly: true
           {{ end }}
-          {{ if or .Values.cloudsql.enabled .Values.fileSecretMounts.enabled .Values.pvc.enabled}}
+          {{ if or .Values.cloudsql.enabled .Values.fileSecretMounts.enabled .Values.pvc.enabled .Values.multiplePvc.enabled }}
           volumes:
             {{ if .Values.cloudsql.enabled }}
             - name: "cloud-sql-proxy-service-account-secret"
@@ -268,6 +274,12 @@ spec:
                 claimName: "{{ include "docker-template.fullname" . }}-pvc"
                 {{- end }}
             {{ end }}
+            {{ if .Values.multiplePvc.enabled }}
+            {{- range .Values.multiplePvc.volumes }}
+            - name: {{ .name }}
+              persistentVolumeClaim:
+                claimName: {{ .existingVolume }}
+            {{- end }}
             {{ if .Values.fileSecretMounts.enabled }}
             {{ range .Values.fileSecretMounts.mounts }}
             - name: {{ .mountPath }}

--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -280,6 +280,7 @@ spec:
               persistentVolumeClaim:
                 claimName: {{ .existingVolume }}
             {{- end }}
+            {{ end }}
             {{ if .Values.fileSecretMounts.enabled }}
             {{ range .Values.fileSecretMounts.mounts }}
             - name: {{ .mountPath }}

--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -111,5 +111,13 @@ pvc:
   mountPath: /mypath
   existingVolume: ""
 
+multiplePvc:
+  enabled: false
+  volumes:
+    - name: ""
+      storage: 20Gi
+      mountPath: /mypath
+      existingVolume: ""
+
 # job timeout configuration
 activeDeadlineSeconds: # Optional - if not set, will use sidecar.timeout

--- a/applications/web/templates/_helpers.tpl
+++ b/applications/web/templates/_helpers.tpl
@@ -180,7 +180,7 @@ Return true if volumeMounts should be rendered in the main container
 
 */}}
 {{- define "web.shouldRenderVolumeMounts" -}}
-{{- if or .Values.datadogSocketVolume.enabled .Values.resources.requests.nvidiaGpu .Values.awsEfsStorage .Values.pvc.enabled .Values.emptyDir.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) -}}
+{{- if or .Values.datadogSocketVolume.enabled .Values.resources.requests.nvidiaGpu .Values.awsEfsStorage .Values.pvc.enabled .Values.multiplePvc.enabled .Values.emptyDir.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) -}}
 true
 {{- else -}}
 false

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -442,6 +442,12 @@ spec:
             - name: "{{ include "docker-template.fullname" . }}-storage"
               mountPath: {{ .Values.pvc.mountPath }}
           {{ end }}
+          {{- if .Values.multiplePvc.enabled }}
+            {{- range .Values.multiplePvc.volumes }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
+            {{- end }}
           {{- if .Values.emptyDir.enabled }}
             - name: "{{ include "docker-template.fullname" . }}-empty-dir-storage"
               mountPath: {{ .Values.emptyDir.mountPath }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -521,7 +521,7 @@ spec:
               {{- end }}
           {{- end }}
       {{ end }}
-      {{ if or .Values.pvc.enabled .Values.resources.requests.nvidiaGpu .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.fileSecretMounts.enabled .Values.awsEfsStorage .Values.datadogSocketVolume.enabled }}
+      {{ if or .Values.pvc.enabled .Values.multiplePvc.enabled .Values.resources.requests.nvidiaGpu .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.fileSecretMounts.enabled .Values.awsEfsStorage .Values.datadogSocketVolume.enabled }}
       volumes:
         {{ if .Values.datadogSocketVolume.enabled }}
         - hostPath:
@@ -553,6 +553,12 @@ spec:
             claimName: "{{ include "docker-template.fullname" . }}-pvc"
         {{ end }}
         {{ end }}
+        {{ if .Values.multiplePvc.enabled }}
+        {{- range .Values.multiplePvc.volumes }}
+        - name: {{ .name }}
+          persistentVolumeClaim:
+            claimName: {{ .existingVolume }}
+        {{- end }}
         {{ if .Values.emptyDir.enabled }}
         - name: "{{ include "docker-template.fullname" . }}-empty-dir-storage"
           emptyDir:

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -565,6 +565,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .existingVolume }}
         {{- end }}
+        {{ end }}
         {{ if .Values.emptyDir.enabled }}
         - name: "{{ include "docker-template.fullname" . }}-empty-dir-storage"
           emptyDir:

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -238,6 +238,14 @@ pvc:
   mountPath: /mypath
   existingVolume: ""
 
+multiplePvc:
+  enabled: false
+  volumes:
+    - name: ""
+      storage: 20Gi
+      mountPath: /mypath
+      existingVolume: ""
+
 cloudsql:
   enabled: false
   connections: []

--- a/applications/worker/templates/_helpers.tpl
+++ b/applications/worker/templates/_helpers.tpl
@@ -101,7 +101,7 @@ For backwards compatibility, this concatenates targets from cloudsql.connectionN
 Return true if volumeMounts should be rendered in the main container
 */}}
 {{- define "worker.shouldRenderVolumeMounts" -}}
-{{- if or .Values.datadogSocketVolume.enabled .Values.pvc.enabled .Values.emptyDir.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) .Values.additionalVolumes -}}
+{{- if or .Values.datadogSocketVolume.enabled .Values.pvc.enabled .Values.multiplePvc.enabled .Values.emptyDir.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) .Values.additionalVolumes -}}
 true
 {{- else -}}
 false

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -323,6 +323,12 @@ spec:
             - name: "{{ include "docker-template.fullname" . }}-storage"
               mountPath: {{ .Values.pvc.mountPath }}
             {{ end }}
+            {{- if .Values.multiplePvc.enabled }}
+            {{- range .Values.multiplePvc.volumes }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.emptyDir.enabled }}
             - name: "{{ include "docker-template.fullname" . }}-empty-dir-storage"
               mountPath: {{ .Values.emptyDir.mountPath }}
@@ -408,7 +414,7 @@ spec:
               {{- end }}
           {{- end }}
       {{ end }}
-      {{ if or .Values.pvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.datadogSocketVolume.enabled .Values.fileSecretMounts.enabled (and .Values.additionalVolumes (not (empty .Values.additionalVolumes))) }}
+      {{ if or .Values.pvc.enabled .Values.multiplePvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.datadogSocketVolume.enabled .Values.fileSecretMounts.enabled (and .Values.additionalVolumes (not (empty .Values.additionalVolumes))) }}
       volumes:
         {{ if .Values.datadogSocketVolume.enabled }}
         - hostPath:
@@ -433,6 +439,13 @@ spec:
             {{- else }}
             claimName: "{{ include "docker-template.fullname" . }}-pvc"
             {{- end }}
+        {{ end }}
+        {{ if .Values.multiplePvc.enabled }}
+        {{- range .Values.multiplePvc.volumes }}
+        - name: {{ .name }}
+          persistentVolumeClaim:
+            claimName: {{ .existingVolume }}
+        {{- end }}
         {{ end }}
         {{ if .Values.emptyDir.enabled }}
         - name: "{{ include "docker-template.fullname" . }}-empty-dir-storage"

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -140,6 +140,14 @@ pvc:
   mountPath: /mypath
   existingVolume: ""
 
+multiplePvc:
+  enabled: false
+  volumes:
+    - name: ""
+      storage: 20Gi
+      mountPath: /mypath
+      existingVolume: ""
+
 cloudsql:
   enabled: false
   connections: []


### PR DESCRIPTION
This PR adds preliminary support for attaching multiple PVCs to a Porter app. This is currently aimed at users who may be using third-party CSI adapters for mounting object store buckets as `PersistentVolumes`, so the assumption is that users will provide the corresponding `PersistentVolumeClaim` names. A typical sample configuration would look like this:

```
multiplePvc:
  enabled: true
  volumes:
    - name: vol1
      mountPath: /manual1
      existingVolume: manual-pvc-mount-test
    - name: vol2
      mountPath: /manual2
      existingVolume: manual-pvc-mount-test-1
 ```    