### PR TITLE
Support for ECK

### DIFF
--- a/addons/eck-stack/.helmignore
+++ b/addons/eck-stack/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+templates/tests
+charts/*/templates/tests

--- a/addons/eck-stack/Chart.lock
+++ b/addons/eck-stack/Chart.lock
@@ -1,0 +1,27 @@
+dependencies:
+- name: eck-elasticsearch
+  repository: ""
+  version: 0.16.0
+- name: eck-kibana
+  repository: ""
+  version: 0.16.0
+- name: eck-agent
+  repository: ""
+  version: 0.16.0
+- name: eck-fleet-server
+  repository: ""
+  version: 0.16.0
+- name: eck-beats
+  repository: ""
+  version: 0.16.0
+- name: eck-logstash
+  repository: ""
+  version: 0.16.0
+- name: eck-apm-server
+  repository: ""
+  version: 0.16.0
+- name: eck-enterprise-search
+  repository: ""
+  version: 0.16.0
+digest: sha256:e6edc40e5df5c9df93965f52c5cce6ef9a2ae3a6d71750bc522632c7731c4957
+generated: "2025-07-29T14:57:40.491351384Z"

--- a/addons/eck-stack/Chart.yaml
+++ b/addons/eck-stack/Chart.yaml
@@ -1,0 +1,39 @@
+apiVersion: v2
+dependencies:
+- condition: eck-elasticsearch.enabled
+  name: eck-elasticsearch
+  repository: ""
+  version: 0.16.0
+- condition: eck-kibana.enabled
+  name: eck-kibana
+  repository: ""
+  version: 0.16.0
+- condition: eck-agent.enabled
+  name: eck-agent
+  repository: ""
+  version: 0.16.0
+- condition: eck-fleet-server.enabled
+  name: eck-fleet-server
+  repository: ""
+  version: 0.16.0
+- condition: eck-beats.enabled
+  name: eck-beats
+  repository: ""
+  version: 0.16.0
+- condition: eck-logstash.enabled
+  name: eck-logstash
+  repository: ""
+  version: 0.16.0
+- condition: eck-apm-server.enabled
+  name: eck-apm-server
+  repository: ""
+  version: 0.16.0
+- condition: eck-enterprise-search.enabled
+  name: eck-enterprise-search
+  repository: ""
+  version: 0.16.0
+description: Elastic Stack managed by the ECK Operator
+kubeVersion: '>= 1.21.0-0'
+name: eck-stack
+type: application
+version: 0.16.0

--- a/addons/eck-stack/README.md
+++ b/addons/eck-stack/README.md
@@ -1,0 +1,93 @@
+# ECK-Stack
+
+ECK Stack is a Helm chart to assist in the deployment of Elastic Stack components, which are
+managed by the [ECK Operator](https://www.elastic.co/guide/en/cloud-on-k8s/current/index.html)
+
+## Supported Elastic Stack Resources
+
+The following Elastic Stack resources are currently supported. 
+
+- Elasticsearch
+- Kibana
+- Elastic Agent
+- Fleet Server
+- Beats
+- Logstash
+- APM Server
+
+Additional resources will be supported in future releases of this Helm Chart.
+
+## Prerequisites
+
+- Kubernetes 1.21+
+- Elastic ECK Operator
+
+## Installing the Chart
+
+### Installing the ECK Operator
+
+Before using this chart, the Elastic ECK Operator is required to be installed within the Kubernetes cluster.
+Full installation instructions can be found within [our documentation](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-installing-eck.html)
+
+To install the ECK Operator using Helm.
+
+```sh
+# Add the Elastic Helm Repository
+helm repo add elastic https://helm.elastic.co && helm repo update
+
+# Install the ECK Operator cluster-wide
+helm install elastic-operator elastic/eck-operator -n elastic-system --create-namespace
+```
+
+Additional ECK Operator Helm installation options can be found within [our documentation](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-install-helm.html)
+
+### Installing the ECK Stack Chart
+
+The following will install the ECK-Stack chart using the default values, which will deploy an Elasticsearch [Quickstart Cluster](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-elasticsearch.html), and a Kibana [Quickstart Instance](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-kibana.html)
+
+```sh
+# Add the Elastic Helm Repository
+helm repo add elastic https://helm.elastic.co && helm repo update
+
+# Install the ECK-Stack helm chart
+# This will setup a 'quickstart' Elasticsearch and Kibana resource in the 'elastic-stack' namespace
+helm install my-release elastic/eck-stack -n elastic-stack --create-namespace
+```
+
+More information on the different ways to use the ECK Stack chart to deploy Elastic Stack resources
+can be found in [our documentation](https://www.elastic.co/guide/en/cloud-on-k8s/current/index.html).
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment from the 'elastic-stack' namespace:
+
+```console
+helm delete my-release -n elastic-stack
+```
+
+The command removes all the Elastic Stack resources associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the eck-stack chart and their default values.
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `eck-elasticsearch.enabled` | If `true`, create an Elasticsearch resource (using the eck-elasticsearch Chart) | `true` |
+| `eck-kibana.enabled` | If `true`, create a Kibana resource (using the eck-kibana Chart) | `true` |
+| `eck-agent.enabled` | If `true`, create an Elastic Agent resource (using the eck-agent Chart) | `false` |
+| `eck-fleet-server.enabled` | If `true`, create a Fleet Server resource (using the eck-fleet-server Chart) | `false` |
+| `eck-logstash.enabled` | If `true`, create a Logstash resource (using the eck-logstash Chart) | `false` |
+| `eck-apm-server.enabled` | If `true`, create a standalone Elastic APM Server resource (using the eck-apm-server Chart) | `false` |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install my-release -f values.yaml .
+```
+
+## Contributing
+
+This chart is maintained at [github.com/elastic/cloud-on-k8s](https://github.com/elastic/cloud-on-k8s/tree/main/deploy/eck-stack).

--- a/addons/eck-stack/charts/eck-agent/.helmignore
+++ b/addons/eck-stack/charts/eck-agent/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+templates/tests

--- a/addons/eck-stack/charts/eck-agent/Chart.yaml
+++ b/addons/eck-stack/charts/eck-agent/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+description: Elastic Agent managed by the ECK operator
+icon: https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt77c2da6e0198746e/620ac24e6662ca0a6f617114/icon-agent-32-color.svg
+kubeVersion: '>= 1.21.0-0'
+name: eck-agent
+sources:
+- https://github.com/elastic/cloud-on-k8s
+- https://github.com/elastic/elastic-agent
+type: application
+version: 0.16.0

--- a/addons/eck-stack/charts/eck-agent/LICENSE
+++ b/addons/eck-stack/charts/eck-agent/LICENSE
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/addons/eck-stack/charts/eck-agent/examples/fleet-agents.yaml
+++ b/addons/eck-stack/charts/eck-agent/examples/fleet-agents.yaml
@@ -1,0 +1,24 @@
+# The following example should only be used in conjunction with the 'eck-fleet-server' Helm Chart,
+# and shows how the Agents can be deployed as a daemonset, and controlled by Fleet Server.
+#
+version: 9.1.0
+
+# This must match the name of an Agent policy.
+policyID: eck-agent
+# This must match the name of the fleet server installed from eck-fleet-server chart.
+fleetServerRef:
+  name: eck-fleet-server
+kibanaRef:
+  name: eck-kibana
+mode: fleet
+# elasticsearchRefs must be empty when fleet mode is enabled.
+elasticsearchRefs: []
+daemonSet:
+  podTemplate:
+    spec:
+      serviceAccountName: elastic-agent
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      automountServiceAccountToken: true
+      securityContext:
+        runAsUser: 0

--- a/addons/eck-stack/charts/eck-agent/examples/system-integration.yaml
+++ b/addons/eck-stack/charts/eck-agent/examples/system-integration.yaml
@@ -1,0 +1,133 @@
+# The following example should only be used in Agent "standalone" mode,
+# and should not be used when Agent is used with Fleet Server.
+#
+version: 9.1.0
+elasticsearchRefs:
+- name: eck-elasticsearch
+daemonSet:
+  podTemplate:
+    spec:
+      containers:
+      - name: agent
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: agent-data
+          mountPath: /usr/share/elastic-agent/data/elastic-agent-08e204/run
+config:
+  id: 488e0b80-3634-11eb-8208-57893829af4e
+  revision: 2
+  agent:
+    monitoring:
+      enabled: true
+      use_output: default
+      logs: true
+      metrics: true
+  inputs:
+  - id: 4917ade0-3634-11eb-8208-57893829af4e
+    name: system-1
+    revision: 1
+    type: system/metrics
+    use_output: default
+    meta:
+      package:
+        name: system
+        version: 9.1.0
+    data_stream:
+      namespace: default
+    streams:
+    - id: system/metrics-system.cpu
+      data_stream:
+        dataset: system.cpu
+        type: metrics
+      metricsets:
+      - cpu
+      cpu.metrics:
+      - percentages
+      - normalized_percentages
+      period: 10s
+    - id: system/metrics-system.diskio
+      data_stream:
+        dataset: system.diskio
+        type: metrics
+      metricsets:
+      - diskio
+      diskio.include_devices: null
+      period: 10s
+    - id: system/metrics-system.filesystem
+      data_stream:
+        dataset: system.filesystem
+        type: metrics
+      metricsets:
+      - filesystem
+      period: 1m
+      processors:
+      - drop_event.when.regexp:
+          system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
+    - id: system/metrics-system.fsstat
+      data_stream:
+        dataset: system.fsstat
+        type: metrics
+      metricsets:
+      - fsstat
+      period: 1m
+      processors:
+      - drop_event.when.regexp:
+          system.fsstat.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
+    - id: system/metrics-system.load
+      data_stream:
+        dataset: system.load
+        type: metrics
+      metricsets:
+      - load
+      period: 10s
+    - id: system/metrics-system.memory
+      data_stream:
+        dataset: system.memory
+        type: metrics
+      metricsets:
+      - memory
+      period: 10s
+    - id: system/metrics-system.network
+      data_stream:
+        dataset: system.network
+        type: metrics
+      metricsets:
+      - network
+      period: 10s
+      network.interfaces: null
+    - id: system/metrics-system.process
+      data_stream:
+        dataset: system.process
+        type: metrics
+      metricsets:
+      - process
+      period: 10s
+      process.include_top_n.by_cpu: 5
+      process.include_top_n.by_memory: 5
+      process.cmdline.cache.enabled: true
+      process.cgroups.enabled: false
+      process.include_cpu_ticks: false
+      processes:
+      - .*
+    - id: system/metrics-system.process_summary
+      data_stream:
+        dataset: system.process_summary
+        type: metrics
+      metricsets:
+      - process_summary
+      period: 10s
+    - id: system/metrics-system.socket_summary
+      data_stream:
+        dataset: system.socket_summary
+        type: metrics
+      metricsets:
+      - socket_summary
+      period: 10s
+    - id: system/metrics-system.uptime
+      data_stream:
+        dataset: system.uptime
+        type: metrics
+      metricsets:
+      - uptime
+      period: 10s

--- a/addons/eck-stack/charts/eck-agent/templates/NOTES.txt
+++ b/addons/eck-stack/charts/eck-agent/templates/NOTES.txt
@@ -1,0 +1,6 @@
+
+1. Check Elastic Agent status
+  $ kubectl get agent {{ include "elasticagent.fullname" . }} -n {{ .Release.Namespace }}
+
+2. Check Elastic Agent pod status
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l agent.k8s.elastic.co/name={{ include "elasticagent.fullname" . }}

--- a/addons/eck-stack/charts/eck-agent/templates/_helpers.tpl
+++ b/addons/eck-stack/charts/eck-agent/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "elasticagent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "elasticagent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "elasticagent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "elasticagent.labels" -}}
+helm.sh/chart: {{ include "elasticagent.chart" . }}
+{{ include "elasticagent.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "elasticagent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "elasticagent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-agent/templates/cluster-role-binding.yaml
+++ b/addons/eck-stack/charts/eck-agent/templates/cluster-role-binding.yaml
@@ -1,0 +1,33 @@
+{{- with .Values.clusterRoleBinding }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "elasticagent.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or $.Values.annotations .annotations }}
+  annotations:
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- with .subjects }}
+subjects:
+{{- range . }}
+  - kind: {{ .kind }}
+    name: {{ .name }}
+    namespace: {{ .namespace | default $.Release.Namespace | quote }}
+{{- end }}
+{{- end }}
+roleRef:
+  kind: {{ .roleRef.kind }}
+  name: {{ .roleRef.name }}
+  apiGroup: {{ .roleRef.apiGroup }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-agent/templates/cluster-role.yaml
+++ b/addons/eck-stack/charts/eck-agent/templates/cluster-role.yaml
@@ -1,0 +1,22 @@
+{{- with .Values.clusterRole }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "elasticagent.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or $.Values.annotations .annotations }}
+  annotations:
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+rules: {{- toYaml .rules | nindent 2 }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-agent/templates/elastic-agent.yaml
+++ b/addons/eck-stack/charts/eck-agent/templates/elastic-agent.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: {{ include "elasticagent.fullname" . }}
+  labels:
+    {{- include "elasticagent.labels" $ | nindent 4 }}
+  annotations:
+    eck.k8s.elastic.co/license: basic
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  version: {{ required "An Elastic Agent version is required" (or ((.Values.spec).version) (.Values.version)) }}
+  {{- $daemonSet := (or (hasKey (.Values.spec) "daemonSet") (hasKey .Values "daemonSet")) }}
+  {{- $deployment := (or (hasKey (.Values.spec) "deployment") (hasKey .Values "deployment")) }}
+  {{- $statefulSet := (or (hasKey (.Values.spec) "statefulSet") (hasKey .Values "statefulSet")) }}
+  {{- if and (not $daemonSet) (not $deployment) (not $statefulSet) }}
+  {{ fail "At least one of daemonSet, deployment or statefulSet is required" }}
+  {{- end }}
+  {{- if $daemonSet }}
+  {{- $ds := or ((.Values.spec).daemonSet) (.Values.daemonSet) }}
+  daemonSet:
+    {{- /* This is required to render the empty daemonset ( {} ) properly */}}
+    {{- $ds | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $deployment }}
+  {{- $deploy := or ((.Values.spec).deployment) (.Values.deployment) }}
+  deployment:
+    {{- /* This is required to render the empty deployment ( {} ) properly */}}
+    {{- $deploy | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $statefulSet }}
+  {{- $sts := or ((.Values.spec).statefulSet) (.Values.statefulSet) }}
+  statefulSet:
+    {{- /* This is required to render the empty statefulSet ( {} ) properly */}}
+    {{- $sts | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).image) (.Values.image) }}
+  image: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).elasticsearchRefs) (.Values.elasticsearchRefs) }}
+  elasticsearchRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).kibanaRef) (.Values.kibanaRef) }}
+  kibanaRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).fleetServerRef) (.Values.fleetServerRef) }}
+  fleetServerRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $config := or ((.Values.spec).config) (.Values.config) }}
+  {{- $configRef := or ((.Values.spec).configRef) (.Values.configRef) }}
+  {{- if and $config $configRef }}
+  {{ fail "Only one of config and configRef can be specified" }}
+  {{- end }}
+  {{- with $config }}
+  config:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $configRef }}
+  configRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).mode) (.Values.mode) }}
+  mode: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).fleetServerEnabled) (.Values.fleetServerEnabled) }}
+  fleetServerEnabled: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).http) (.Values.http) }}
+  http:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).policyID) (.Values.policyID) }}
+  policyID: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).secureSettings) (.Values.secureSettings) }}
+  secureSettings:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).revisionHistoryLimit) (.Values.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with or (((.Values.spec).serviceAccount).name) ((.Values.serviceAccount).name) }}
+  serviceAccountName: {{ . }}
+  {{- end }}

--- a/addons/eck-stack/charts/eck-agent/templates/service-account.yaml
+++ b/addons/eck-stack/charts/eck-agent/templates/service-account.yaml
@@ -1,0 +1,22 @@
+{{- with .Values.serviceAccount }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace | default $.Release.Namespace | quote }}
+  labels:
+    {{- include "elasticagent.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or $.Values.annotations .annotations }}
+  annotations:
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-agent/values.yaml
+++ b/addons/eck-stack/charts/eck-agent/values.yaml
@@ -1,0 +1,245 @@
+---
+# Default values for eck-agent.
+# This is a YAML-formatted file.
+
+# Overridable names of the Elastic Agent resource.
+# By default, this is the Release name set for the chart,
+# followed by 'eck-agent'.
+#
+# nameOverride will override the name of the Chart with the name set here,
+# so nameOverride: quickstart, would convert to '{{ Release.name }}-quickstart'
+#
+# nameOverride: "quickstart"
+#
+# fullnameOverride will override both the release name, and the chart name,
+# and will name the Fleet Agent resource exactly as specified.
+#
+# fullnameOverride: "quickstart"
+
+# Version of Elastic Agent.
+#
+version: 9.1.0
+
+# Labels that will be applied to Elastic Agent.
+#
+labels: {}
+
+# Annotations that will be applied to Elastic Agent.
+#
+annotations: {}
+
+# Elastic Agent image to deploy.
+#
+# image: docker.elastic.co/beats/elastic-agent:9.1.0
+
+# ** Deprecation Notice **
+# The previous versions of this Helm Chart simply used the `spec` field here
+# and allowed the user to specify any fields below `spec` that were templated directly
+# into the final Kibana manifest. This is no longer the preferred way to specify these
+# fields and each field that is supported underneath `spec` is now directly specified
+# in this values file. Currently both patterns are supported for backwards compatibility
+# but we plan to remove the `spec` field in the future.
+# spec: {}
+
+# Referenced resources are below and depending on the setup, at least one is required for a functional Agent.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-setting-referenced-resources
+#
+# Reference to ECK-managed Kibana instance.
+#
+# kibanaRef:
+#   name: quickstart
+  # Optional namespace reference to Kibana instance.
+  # If not specified, then the namespace of the Agent instance
+  # will be assumed.
+  #
+  # namespace: default
+
+# Reference to ECK-managed Elasticsearch instance.
+#
+elasticsearchRefs:
+- name: eck-elasticsearch
+  # Optional namespace reference to Elasticsearch instance.
+  # If not specified, then the namespace of the Agent instance
+  # will be assumed.
+  #
+  # namespace: default
+
+# Reference to ECK-managed Fleet Server instance.
+#
+# fleetServerRef:
+#   name: eck-fleet-server
+  # Optional namespace reference to Fleet Server instance.
+  # If not specified, then the namespace of the Agent instance
+  # will be assumed.
+  #
+  # namespace: default
+
+# The Elastic Agent configuration, the ECK equivalent to agent.yml
+# NOTE: The `config` and `configRef` fields are mutually exclusive. Only one of them should be defined at a time,
+# as using both may cause conflicts.
+#
+# Configuration of Agent, specifically used in Agent standalone mode.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-configuration.html
+#
+config: null
+
+# Reference a configuration in a Secret.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-configuration.html
+#
+# configRef:
+#   secretName: ""
+
+# The mode of Agent to use. Only set to "fleet" when Fleet Server is enabled.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-fleet-mode-and-fleet-server
+#
+# mode: "fleet"
+
+# fleetServerEnabled determines whether the Agent will be run as the Fleet Server.
+#
+# NOTE: Both `mode: fleet` and `fleetServerEnabled: true` need to be set for Fleet Server to be enabled.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-fleet-mode-and-fleet-server
+#
+fleetServerEnabled: false
+
+# The HTTP layer configuration for the Fleet Server Service.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-customize-fleet-server-service
+#
+# http:
+
+# policyID determines into which Agent Policy this Agent will be enrolled.
+# policyID: eck-agent
+  
+# DaemonSet, StatefulSet, or Deployment specification for Agent.
+# At least one is required of [daemonSet, deployment, statefulSet].
+# No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-chose-the-deployment-model
+#
+# deployment:
+#   podTemplate:
+#     spec:
+#       containers:
+#       - name: agent
+#         securityContext:
+#           runAsUser: 0
+# daemonSet:
+#   podTemplate:
+#     spec:
+#       containers:
+#       - name: agent
+#         securityContext:
+#           runAsUser: 0
+# statefulSet:
+#   podTemplate:
+#     spec:
+#       containers:
+#       - name: agent
+#         securityContext:
+#           runAsUser: 0
+
+# SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for Elastic Agent.
+secureSettings: []
+# - secretName: my-secret-with-secure-settings
+
+# Number of revisions to retain to allow rollback in the underlying Deployment.
+# If not set Kubernetes sets this to 10 by default.
+#
+# revisionHistoryLimit: 2
+
+# ServiceAccount to be used by Elastic Agent. Some Elastic Agent features, such as the Kubernetes integration,
+# require that Agent Pods interact with Kubernetes APIs. This functionality requires specific permissions
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-role-based-access-control
+#
+serviceAccount:
+  name: elastic-agent
+  # { .Release.Namespace } is used here by default, but can be specified.
+  # namespace: optional-namespace
+
+# ClusterRoleBinding to be used by Elastic Agent. Similar to ServiceAccount, this is required in some scenarios.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-role-based-access-control
+#
+clusterRoleBinding:
+  name: elastic-agent
+  subjects:
+  - kind: ServiceAccount
+    name: elastic-agent
+    # { .Release.Namespace } is used here by default, but can be specified.
+    # namespace: default
+  roleRef:
+    kind: ClusterRole
+    name: elastic-agent
+    apiGroup: rbac.authorization.k8s.io
+
+# ClusterRole to be used by Elastic Agent. Similar to ServiceAccount, this is required in some scenarios.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-role-based-access-control
+#
+clusterRole:
+  name: elastic-agent
+  rules:
+  - apiGroups: [""]
+    resources:
+    - pods
+    - nodes
+    - namespaces
+    - events
+    - services
+    - configmaps
+    verbs:
+    - get
+    - watch
+    - list
+  - apiGroups: ["coordination.k8s.io"]
+    resources:
+    - leases
+    verbs:
+    - get
+    - create
+    - update
+  - nonResourceURLs:
+    - "/metrics"
+    verbs:
+    - get
+  - apiGroups: ["extensions"]
+    resources:
+      - replicasets
+    verbs: 
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - "apps"
+    resources:
+    - statefulsets
+    - deployments
+    - replicasets
+    - daemonsets
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/stats
+    verbs:
+    - get
+  - nonResourceURLs:
+    - "/metrics"
+    verbs:
+    - get
+  - apiGroups:
+    - "batch"
+    resources:
+    - jobs
+    - cronjobs
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - "storage.k8s.io"
+    resources:
+    - storageclasses
+    verbs:
+    - "get"
+    - "list"
+    - "watch"

--- a/addons/eck-stack/charts/eck-apm-server/.helmignore
+++ b/addons/eck-stack/charts/eck-apm-server/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+templates/tests

--- a/addons/eck-stack/charts/eck-apm-server/Chart.yaml
+++ b/addons/eck-stack/charts/eck-apm-server/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+description: Elastic APM Server managed by the ECK operator
+icon: https://helm.elastic.co/icons/apm.png
+kubeVersion: '>= 1.21.0-0'
+name: eck-apm-server
+sources:
+- https://github.com/elastic/cloud-on-k8s
+- https://github.com/elastic/apm-server
+type: application
+version: 0.16.0

--- a/addons/eck-stack/charts/eck-apm-server/LICENSE
+++ b/addons/eck-stack/charts/eck-apm-server/LICENSE
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/addons/eck-stack/charts/eck-apm-server/examples/jaeger-with-http-configuration.yaml
+++ b/addons/eck-stack/charts/eck-apm-server/examples/jaeger-with-http-configuration.yaml
@@ -1,0 +1,29 @@
+---
+# Version of APM Server.
+#
+version: 9.1.0
+
+# Count of APM Server replicas to create.
+#
+count: 1
+
+config:
+  name: elastic-apm
+  apm-server.jaeger.grpc.enabled: true
+  apm-server.jaeger.grpc.host: "0.0.0.0:14250"
+
+# Reference to ECK-managed Elasticsearch resource.
+#
+elasticsearchRef:
+  name: eck-elasticsearch
+http:
+  service:
+    spec:
+      ports:
+      - name: http
+        port: 8200
+        targetPort: 8200
+      - name: grpc
+        port: 14250
+        targetPort: 14250
+

--- a/addons/eck-stack/charts/eck-apm-server/templates/NOTES.txt
+++ b/addons/eck-stack/charts/eck-apm-server/templates/NOTES.txt
@@ -1,0 +1,6 @@
+
+1. Check APM Server status
+  $ kubectl get apmserver {{ include "apm-server.fullname" . }} -n {{ .Release.Namespace }}
+
+2. Check APM Server pod status
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l apm.k8s.elastic.co/name={{ include "apm-server.fullname" . }}

--- a/addons/eck-stack/charts/eck-apm-server/templates/_helpers.tpl
+++ b/addons/eck-stack/charts/eck-apm-server/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "apm-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "apm-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "apm-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "apm-server.labels" -}}
+helm.sh/chart: {{ include "apm-server.chart" . }}
+{{ include "apm-server.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "apm-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "apm-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-apm-server/templates/apmserver.yaml
+++ b/addons/eck-stack/charts/eck-apm-server/templates/apmserver.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: apm.k8s.elastic.co/v1
+kind: ApmServer
+metadata:
+  name: {{ include "apm-server.fullname" . }}
+  labels:
+    {{- include "apm-server.labels" . | nindent 4 }}
+  annotations:
+    eck.k8s.elastic.co/license: basic
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  version: {{ required "An APM Server version is required" .Values.version }}
+  count: {{ required "A pod count is required" .Values.count }}
+  {{- with .Values.image }}
+  image: {{ . }}
+  {{- end }}
+  {{- with .Values.serviceAccountName }}
+  serviceAccountName: {{ . }}
+  {{- end }}
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+
+  {{- with .Values.config }}
+  config:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.http }}
+  http:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.elasticsearchRef }}
+  elasticsearchRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.kibanaRef }}
+  kibanaRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.podTemplate }}
+  podTemplate:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.secureSettings }}
+  secureSettings:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/addons/eck-stack/charts/eck-apm-server/values.yaml
+++ b/addons/eck-stack/charts/eck-apm-server/values.yaml
@@ -1,0 +1,97 @@
+---
+# Default values for eck-apm-server.
+# This is a YAML-formatted file.
+
+# Overridable names of the APM Server resource.
+# By default, this is the Release name set for the chart,
+# followed by 'eck-apm-server'.
+#
+# nameOverride will override the name of the Chart with the name set here,
+# so nameOverride: quickstart, would convert to '{{ Release.name }}-quickstart'
+#
+# nameOverride: "quickstart"
+#
+# fullnameOverride will override both the release name, and the chart name,
+# and will name the APM Server resource exactly as specified.
+#
+# fullnameOverride: "quickstart"
+
+# Version of APM Server.
+#
+version: 9.1.0
+
+# APM Server Docker image to deploy
+#
+# image:
+
+# Used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
+# Can only be used if ECK is enforcing RBAC on references.
+#
+# serviceAccountName: ""
+
+# Labels that will be applied to APM Server.
+#
+labels: {}
+
+# Annotations that will be applied to APM Server.
+#
+annotations: {}
+
+# Count of APM Server replicas to create.
+#
+count: 1
+
+# The APM Server configuration, the ECK equivalent to apm-server.yml
+# ref: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html
+#
+config: {}
+
+# Settings to control how APM Server will be accessed.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-accessing-elastic-services.html
+#
+http: {}
+  # service:
+  #   metadata:
+  #     labels:
+  #       my-custom: label
+  #   spec:
+  #     ports:
+  #     - name: http
+  #       port: 8200
+  #       targetPort: 8200
+
+# Reference to ECK-managed Elasticsearch resource.
+#
+elasticsearchRef: {}
+  # name: eck-elasticsearch
+  # Optional namespace reference to Elasticsearch resource.
+  # If not specified, then the namespace of the APM Server resource
+  # will be assumed.
+  #
+  # namespace: default
+
+# Optional reference to ECK-managed Kibana resource which allows ECK to
+# automatically configure the Kibana endpoint as described in 
+# https://www.elastic.co/guide/en/apm/server/current/setup-kibana-endpoint.html
+#
+# kibanaRef:
+#   name: eck-kibana
+#   # Optional namespace reference to Kibana resource.
+#   # If not specified, then the namespace of the APM Server resource
+#   # will be assumed.
+#   #
+#   # namespace: default
+
+# Set podTemplate to customize the pod used by APM Server
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-customize-pods.html
+#
+podTemplate: {}
+
+# Number of revisions to retain to allow rollback in the underlying Deployment.
+# If not set Kubernetes sets this to 10 by default.
+#
+# revisionHistoryLimit: 2
+
+# SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for APM Server.
+secureSettings: []
+# - secretName: my-secret-with-secure-settings

--- a/addons/eck-stack/charts/eck-beats/.helmignore
+++ b/addons/eck-stack/charts/eck-beats/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+templates/tests

--- a/addons/eck-stack/charts/eck-beats/Chart.yaml
+++ b/addons/eck-stack/charts/eck-beats/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+description: Elastic Beats managed by the ECK operator
+icon: https://helm.elastic.co/icons/beats.png
+kubeVersion: '>= 1.20.0-0'
+name: eck-beats
+sources:
+- https://github.com/elastic/cloud-on-k8s
+- https://github.com/elastic/beats
+type: application
+version: 0.16.0

--- a/addons/eck-stack/charts/eck-beats/LICENSE
+++ b/addons/eck-stack/charts/eck-beats/LICENSE
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/addons/eck-stack/charts/eck-beats/examples/auditbeat_hosts.yaml
+++ b/addons/eck-stack/charts/eck-beats/examples/auditbeat_hosts.yaml
@@ -1,0 +1,110 @@
+name: auditbeat
+version: 9.1.0
+type: auditbeat
+elasticsearchRef:
+  name: eck-elasticsearch
+kibanaRef:
+  name: eck-kibana
+config:
+  auditbeat.modules:
+  - module: file_integrity
+    paths:
+    - /hostfs/bin
+    - /hostfs/usr/bin
+    - /hostfs/sbin
+    - /hostfs/usr/sbin
+    - /hostfs/etc
+    exclude_files:
+    - '(?i)\.sw[nop]$'
+    - '~$'
+    - '/\.git($|/)'
+    scan_at_start: true
+    scan_rate_per_sec: 50 MiB
+    max_file_size: 100 MiB
+    hash_types: [sha1]
+    recursive: true
+  - module: auditd
+    audit_rules: |
+      # Executions
+      -a always,exit -F arch=b64 -S execve,execveat -k exec
+
+      # Unauthorized access attempts (amd64 only)
+      -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
+      -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
+
+  processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+  - add_process_metadata:
+      match_pids: ['process.pid']
+daemonSet:
+  podTemplate:
+    spec:
+      hostPID: true  # Required by auditd module
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true # Allows to provide richer host metadata
+      automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+      securityContext:
+        runAsUser: 0
+      volumes:
+      - name: bin
+        hostPath:
+          path: /bin
+      - name: usrbin
+        hostPath:
+          path: /usr/bin
+      - name: sbin
+        hostPath:
+          path: /sbin
+      - name: usrsbin
+        hostPath:
+          path: /usr/sbin
+      - name: etc
+        hostPath:
+          path: /etc
+      - name: run-containerd
+        hostPath:
+          path: /run/containerd
+          type: DirectoryOrCreate
+      # Uncomment the below when running on GKE. See https://github.com/elastic/beats/issues/8523 for more context.
+      #- name: run
+      #  hostPath:
+      #    path: /run
+      #initContainers:
+      #- name: cos-init
+      #  image: docker.elastic.co/beats/auditbeat:8.3.3
+      #  volumeMounts:
+      #  - name: run
+      #    mountPath: /run
+      #  command: ['sh', '-c', 'export SYSTEMD_IGNORE_CHROOT=1 && systemctl stop systemd-journald-audit.socket && systemctl mask systemd-journald-audit.socket && systemctl restart systemd-journald']
+      containers:
+      - name: auditbeat
+        securityContext:
+          capabilities:
+            add:
+            # Capabilities needed for auditd module
+            - 'AUDIT_READ'
+            - 'AUDIT_WRITE'
+            - 'AUDIT_CONTROL'
+        volumeMounts:
+        - name: bin
+          mountPath: /hostfs/bin
+          readOnly: true
+        - name: sbin
+          mountPath: /hostfs/sbin
+          readOnly: true
+        - name: usrbin
+          mountPath: /hostfs/usr/bin
+          readOnly: true
+        - name: usrsbin
+          mountPath: /hostfs/usr/sbin
+          readOnly: true
+        - name: etc
+          mountPath: /hostfs/etc
+          readOnly: true
+        # Directory with root filesystems of containers executed with containerd, this can be
+        # different with other runtimes. This volume is needed to monitor the file integrity
+        # of files in containers.
+        - name: run-containerd
+          mountPath: /run/containerd
+          readOnly: true

--- a/addons/eck-stack/charts/eck-beats/examples/filebeat_no_autodiscover.yaml
+++ b/addons/eck-stack/charts/eck-beats/examples/filebeat_no_autodiscover.yaml
@@ -1,0 +1,52 @@
+name: filebeat
+version: 9.1.0
+type: filebeat
+elasticsearchRef:
+  name: eck-elasticsearch
+kibanaRef:
+  name: eck-kibana
+config:
+  filebeat.inputs:
+  - type: filestream
+    paths:
+    - /var/log/containers/*.log
+    parsers:
+    - container: ~
+    prospector:
+      scanner:
+        fingerprint.enabled: true
+        symlinks: true
+    file_identity.fingerprint: ~
+  processors:
+  - add_host_metadata: {}
+  - add_cloud_metadata: {}
+daemonSet:
+  podTemplate:
+    spec:
+      automountServiceAccountToken: true
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true # Allows to provide richer host metadata
+      containers:
+      - name: filebeat
+        securityContext:
+          runAsUser: 0
+          # If using Red Hat OpenShift uncomment this:
+          #privileged: true
+        volumeMounts:
+        - name: varlogcontainers
+          mountPath: /var/log/containers
+        - name: varlogpods
+          mountPath: /var/log/pods
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+      volumes:
+      - name: varlogcontainers
+        hostPath:
+          path: /var/log/containers
+      - name: varlogpods
+        hostPath:
+          path: /var/log/pods
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/addons/eck-stack/charts/eck-beats/examples/heartbeat_es_kb_health.yaml
+++ b/addons/eck-stack/charts/eck-beats/examples/heartbeat_es_kb_health.yaml
@@ -1,0 +1,23 @@
+name: heartbeat
+version: 9.1.0
+type: heartbeat
+elasticsearchRef:
+  name: eck-elasticsearch
+config:
+  heartbeat.monitors:
+  - type: tcp
+    schedule: '@every 5s'
+    # This should directly match the name of the Elasticsearch instance
+    # with "-es-http" appended to the name.
+    hosts: ["elasticsearch-es-http.default.svc:9200"]
+  - type: tcp
+    schedule: '@every 5s'
+    # This should directly match the names of the Kibana instance
+    # with "-kb-http" appended to the name.
+    hosts: ["eck-kibana-kb-http.default.svc:5601"]
+deployment:
+  replicas: 1
+  podTemplate:
+    spec:
+      securityContext:
+        runAsUser: 0

--- a/addons/eck-stack/charts/eck-beats/examples/metricbeat_hosts.yaml
+++ b/addons/eck-stack/charts/eck-beats/examples/metricbeat_hosts.yaml
@@ -1,0 +1,158 @@
+name: metricbeat
+type: metricbeat
+version: 9.1.0
+elasticsearchRef:
+  name: eck-elasticsearch
+kibanaRef:
+  name: eck-kibana
+config:
+  metricbeat:
+    autodiscover:
+      providers:
+      - hints:
+          default_config: {}
+          enabled: "true"
+        node: ${NODE_NAME}
+        type: kubernetes
+    modules:
+    - module: system
+      period: 10s
+      metricsets:
+      - cpu
+      - load
+      - memory
+      - network
+      - process
+      - process_summary
+      process:
+        include_top_n:
+          by_cpu: 5
+          by_memory: 5
+      processes:
+      - .*
+    - module: system
+      period: 1m
+      metricsets:
+      - filesystem
+      - fsstat
+      processors:
+      - drop_event:
+          when:
+            regexp:
+              system:
+                filesystem:
+                  mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib)($|/)
+    - module: kubernetes
+      period: 10s
+      node: ${NODE_NAME}
+      hosts:
+      - https://${NODE_NAME}:10250
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      ssl:
+        verification_mode: none
+      metricsets:
+      - node
+      - system
+      - pod
+      - container
+      - volume
+  processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+daemonSet:
+  podTemplate:
+    spec:
+      serviceAccountName: metricbeat
+      automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+      containers:
+      - args:
+        - -e
+        - -c
+        - /etc/beat.yml
+        - --system.hostfs=/hostfs
+        name: metricbeat
+        volumeMounts:
+        - mountPath: /hostfs/sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/run/docker.sock
+          name: dockersock
+        - mountPath: /hostfs/proc
+          name: proc
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true # Allows to provide richer host metadata
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroup
+      - hostPath:
+          path: /var/run/docker.sock
+        name: dockersock
+      - hostPath:
+          path: /proc
+        name: proc
+
+clusterRole:
+  # permissions needed for metricbeat
+  # source: https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-kubernetes.html
+  name: metricbeat
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    - namespaces
+    - events
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - "extensions"
+    resources:
+    - replicasets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - statefulsets
+    - deployments
+    - replicasets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/stats
+    verbs:
+    - get
+  - nonResourceURLs:
+    - /metrics
+    verbs:
+    - get
+
+serviceAccount:
+  name: metricbeat
+
+clusterRoleBinding:
+  name: metricbeat
+  subjects:
+  - kind: ServiceAccount
+    name: metricbeat
+  roleRef:
+    kind: ClusterRole
+    name: metricbeat
+    apiGroup: rbac.authorization.k8s.io

--- a/addons/eck-stack/charts/eck-beats/examples/packetbeat_dns_http.yaml
+++ b/addons/eck-stack/charts/eck-beats/examples/packetbeat_dns_http.yaml
@@ -1,0 +1,37 @@
+name: packetbeat
+type: packetbeat
+version: 9.1.0
+elasticsearchRef:
+  name: eck-elasticsearch
+kibanaRef:
+  name: eck-kibana
+config:
+  packetbeat.interfaces.device: any
+  packetbeat.protocols:
+  - type: dns
+    ports: [53]
+    include_authorities: true
+    include_additionals: true
+  - type: http
+    ports: [80, 8000, 8080, 9200]
+  packetbeat.flows:
+    timeout: 30s
+    period: 10s
+  processors:
+  - add_cloud_metadata: {}
+  - add_host_metadata: {}
+daemonSet:
+  podTemplate:
+    spec:
+      terminationGracePeriodSeconds: 30
+      hostNetwork: true
+      automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: packetbeat
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add:
+            - NET_ADMIN
+      volumes: []

--- a/addons/eck-stack/charts/eck-beats/templates/NOTES.txt
+++ b/addons/eck-stack/charts/eck-beats/templates/NOTES.txt
@@ -1,0 +1,6 @@
+
+1. Check Beat status
+  $ kubectl get beat {{ include "beat.fullname" . }} -n {{ .Release.Namespace }}
+
+2. Check Beat pod status
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l beat.k8s.elastic.co/name={{ include "beat.fullname" . }}

--- a/addons/eck-stack/charts/eck-beats/templates/_helpers.tpl
+++ b/addons/eck-stack/charts/eck-beats/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "beat.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "beat.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "beat.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "beat.labels" -}}
+helm.sh/chart: {{ include "beat.chart" . }}
+{{ include "beat.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "beat.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "beat.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-beats/templates/beats.yaml
+++ b/addons/eck-stack/charts/eck-beats/templates/beats.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: beat.k8s.elastic.co/v1beta1
+kind: Beat
+metadata:
+  name: {{ include "beat.fullname" . }}
+  labels:
+    {{- include "beat.labels" . | nindent 4 }}
+  annotations:
+    eck.k8s.elastic.co/license: basic
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  version: {{ required "A Beat version is required" (or ((.Values.spec).version) (.Values.version)) }}
+  {{- $daemonSet := (or (hasKey (.Values.spec) "daemonSet") (hasKey .Values "daemonSet")) }}
+  {{- $deployment := (or (hasKey (.Values.spec) "deployment") (hasKey .Values "deployment")) }}
+  {{- if and (not $daemonSet) (not $deployment) }}
+  {{ fail "At least one of daemonSet or deployment is required for a functional Beat" }}
+  {{- end }}
+  {{- if not (or ((.Values.spec).type) (.Values.type)) }}{{ fail "A Beat type is required" }}{{- end }}
+  type: {{ or ((.Values.spec).type) (.Values.type) }}
+  {{- if $daemonSet }}
+  {{- $ds := or ((.Values.spec).daemonSet) (.Values.daemonSet) }}
+  daemonSet:
+    {{- /* This is required to render the empty daemonset ( {} ) properly */}}
+    {{- $ds | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $deployment }}
+  {{- $deploy := or ((.Values.spec).deployment) (.Values.deployment) }}
+  deployment:
+    {{- /* This is required to render the empty deployment ( {} ) properly */}}
+    {{- $deploy | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).image) (.Values.image) }}
+  image: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).elasticsearchRef) (.Values.elasticsearchRef) }}
+  elasticsearchRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).kibanaRef) (.Values.kibanaRef) }}
+  kibanaRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $config := or ((.Values.spec).config) (.Values.config) }}
+  {{- $configRef := or ((.Values.spec).configRef) (.Values.configRef) }}
+  {{- if and $config $configRef }}
+  {{ fail "Only one of config and configRef can be specified" }}
+  {{- end }}
+  {{- with $config }}
+  config:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $configRef }}
+  configRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).http) (.Values.http) }}
+  http:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).monitoring) (.Values.monitoring) }}
+  monitoring:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).secureSettings) (.Values.secureSettings) }}
+  secureSettings:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).revisionHistoryLimit) (.Values.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with or (((.Values.spec).serviceAccount).name) ((.Values.serviceAccount).name) }}
+  serviceAccountName: {{ . }}
+  {{- end }}

--- a/addons/eck-stack/charts/eck-beats/templates/cluster-role-binding.yaml
+++ b/addons/eck-stack/charts/eck-beats/templates/cluster-role-binding.yaml
@@ -1,0 +1,35 @@
+{{- with .Values.clusterRoleBinding }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "beat.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or $.Values.annotations .annotations }}
+  annotations:
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- with .subjects }}
+subjects:
+{{- range . }}
+  - kind: {{ .kind }}
+    name: {{ .name }}
+    namespace: {{ .namespace | default $.Release.Namespace | quote }}
+{{- end }}
+{{- end }}
+{{- with .roleRef }}
+roleRef:
+  kind: {{ .kind }}
+  name: {{ .name }}
+  apiGroup: {{ .apiGroup }}
+{{- end }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-beats/templates/cluster-role.yaml
+++ b/addons/eck-stack/charts/eck-beats/templates/cluster-role.yaml
@@ -1,0 +1,22 @@
+{{- with .Values.clusterRole }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "beat.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or $.Values.annotations .annotations }}
+  annotations:
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+rules: {{- toYaml .rules | nindent 2 }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-beats/templates/service-account.yaml
+++ b/addons/eck-stack/charts/eck-beats/templates/service-account.yaml
@@ -1,0 +1,23 @@
+
+{{- with .Values.serviceAccount }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace | default $.Release.Namespace | quote }}
+  labels:
+    {{- include "beat.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or $.Values.annotations .annotations }}
+  annotations:
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-beats/values.yaml
+++ b/addons/eck-stack/charts/eck-beats/values.yaml
@@ -1,0 +1,169 @@
+---
+# Default values for eck-beats.
+# This is a YAML-formatted file.
+
+# Overridable names of the Beats resource.
+# By default, this is the Release name set for the chart,
+# followed by 'eck-beats'.
+#
+# nameOverride will override the name of the Chart with the name set here,
+# so nameOverride: quickstart, would convert to '{{ Release.name }}-quickstart'
+#
+# nameOverride: "quickstart"
+#
+# fullnameOverride will override both the release name, and the chart name,
+# and will name the Beats resource exactly as specified.
+#
+# fullnameOverride: "quickstart"
+
+# Version of Elastic Beats.
+#
+version: 9.1.0
+
+# Labels that will be applied to Elastic Beats.
+#
+labels: {}
+
+# Annotations that will be applied to Elastic Beats.
+#
+annotations: {}
+
+# ** Deprecation Notice **
+# The previous versions of this Helm Chart simply used the `spec` field here
+# and allowed the user to specify any fields below spec that were templated directly
+# into the final Beats manifest. This is no longer the preferred way to specify these
+# fields and each field that is supported underneath `spec` is now directly specified
+# in this values file. Currently both patterns are supported for backwards compatibility
+# but we plan to remove the `spec` field in the future.
+# spec: {}
+
+# Type of Elastic Beats. Standard types of Beat are [filebeat,metricbeat,heartbeat,auditbeat,packetbeat,journalbeat].
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-deploy-elastic-beat
+#
+# Note: This is required to be set, or the release install will fail.
+#
+type: ""
+
+# Beats image to deploy.
+#
+# image: docker.elastic.co/beats/metricbeat:9.1.0
+
+# Referenced resources are below and depending on the setup, at least elasticsearchRef is required for a functional Beat.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-connect-es
+#
+# Reference to ECK-managed Kibana instance.
+#
+# kibanaRef:
+#   name: quickstart
+  # Optional namespace reference to Kibana instance.
+  # If not specified, then the namespace of the Beats instance
+  # will be assumed.
+  #
+  # namespace: default
+
+# Reference to ECK-managed Elasticsearch instance.
+# *Note* If Beat's output is intended to go to Elasticsearch and not something like Logstash,
+# this elasticsearchRef must be updated to the name of the Elasticsearch instance.
+#
+elasticsearchRef: {}
+  # name: elasticsearch
+  # Optional namespace reference to Elasticsearch instance.
+  # If not specified, then the namespace of the Beats instance
+  # will be assumed.
+  #
+  # namespace: default
+
+# Daemonset, or Deployment specification for the type of Beat specified.
+# At least one is required of [daemonSet, deployment].
+# No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-chose-the-deployment-model
+#
+# deployment:
+#   podTemplate:
+#     spec:
+#       securityContext:
+#         runAsUser: 0
+# daemonSet:
+#   podTemplate:
+#     spec:
+#       securityContext:
+#         runAsUser: 0
+
+# Configuration of Beat, which is dependent on the `type` of Beat specified.
+# NOTE: The `config` and `configRef` fields are mutually exclusive. Only one of them should be defined at a time,
+# as using both may cause conflicts.
+#
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-custom-configuration
+#
+config: {}
+
+# Reference a configuration in a Secret.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-custom-configuration
+#
+# configRef:
+#   secretName: ""
+
+# The HTTP layer configuration for the Beats Service.
+#
+# http:
+
+# Settings for configuring stack monitoring.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-stack-monitoring.html
+#
+# monitoring: {}
+  # metrics:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
+  # logs:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
+
+# SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for Elastic Beats.
+secureSettings: []
+# - secretName: my-secret-with-secure-settings
+
+# Number of revisions to retain to allow rollback in the underlying Deployment.
+# If not set Kubernetes sets this to 10 by default.
+#
+# revisionHistoryLimit: 2
+
+# ServiceAccount to be used by Elastic Beats. Some Beats features (such as autodiscover or Kubernetes module metricsets)
+# require that Beat Pods interact with Kubernetes APIs. This functionality requires specific permissions
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-role-based-access-control-for-beats
+#
+serviceAccount: {}
+#  name: elastic-beat-filebeat-quickstart
+#  namespace: optional-namespace
+
+# ClusterRoleBinding to be used by Elastic Beats. Similar to ServiceAccount, this is required in some scenarios.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-role-based-access-control-for-beats
+#
+clusterRoleBinding: {}
+#  name: elastic-beat-autodiscover-binding
+#  subjects:
+#  - kind: ServiceAccount
+#    name: elastic-beat-filebeat-quickstart
+#    namespace: default
+#  roleRef:
+#    kind: ClusterRole
+#    name: elastic-beat-autodiscover
+#    apiGroup: rbac.authorization.k8s.io
+
+# ClusterRole to be used by Elastic Beats. Similar to ServiceAccount, this is required in some scenarios.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration.html#k8s-beat-role-based-access-control-for-beats
+#
+clusterRole: {}
+#  name: elastic-beat-autodiscover
+#  rules:
+#  - apiGroups: [""]
+#    resources:
+#    - events
+#    - pods
+#    - namespaces
+#    - nodes
+#    verbs:
+#    - get
+#    - watch
+#    - list

--- a/addons/eck-stack/charts/eck-elasticsearch/.helmignore
+++ b/addons/eck-stack/charts/eck-elasticsearch/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+templates/tests

--- a/addons/eck-stack/charts/eck-elasticsearch/Chart.yaml
+++ b/addons/eck-stack/charts/eck-elasticsearch/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+description: Elasticsearch managed by the ECK operator
+icon: https://helm.elastic.co/icons/elasticsearch.png
+kubeVersion: '>= 1.21.0-0'
+name: eck-elasticsearch
+sources:
+- https://github.com/elastic/cloud-on-k8s
+- https://github.com/elastic/elasticsearch/
+type: application
+version: 0.16.0

--- a/addons/eck-stack/charts/eck-elasticsearch/LICENSE
+++ b/addons/eck-stack/charts/eck-elasticsearch/LICENSE
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/addons/eck-stack/charts/eck-elasticsearch/examples/hot-warm-cold.yaml
+++ b/addons/eck-stack/charts/eck-elasticsearch/examples/hot-warm-cold.yaml
@@ -1,0 +1,198 @@
+---
+nodeSets:
+- name: masters
+  count: 1
+  config:
+    node.roles: ["master"]
+    # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+    # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+    # and leave node.store.allow_mmap unset.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+    #
+    node.store.allow_mmap: false
+  podTemplate:
+    spec:
+      containers:
+      - name: elasticsearch
+        resources:
+          limits:
+            memory: 8Gi
+            cpu: 2
+      # Affinity/Anti-affinity settings for controlling the 'spreading' of Elasticsearch
+      # pods across existing hosts.
+      # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-affinity-options
+      #
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #       - matchExpressions:
+      #         - key: beta.kubernetes.io/instance-type
+      #           operator: In
+      #           # This should be adjusted to the instance type according to your setup
+      #           #
+      #           values:
+      #           - highio
+  # Volume Claim settings.
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
+  #
+  volumeClaimTemplates:
+  - metadata:
+      name: elasticsearch-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Ti
+      # Adjust to your storage class name
+      #
+      # storageClassName: local-storage
+- name: hot
+  count: 1
+  config:
+    node.roles: ["data_hot", "data_content", "ingest"]
+    # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+    # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+    # and leave node.store.allow_mmap unset.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+    #
+    node.store.allow_mmap: false
+  podTemplate:
+    spec:
+      containers:
+      - name: elasticsearch
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: 4
+      # Affinity/Anti-affinity settings for controlling the 'spreading' of Elasticsearch
+      # pods across existing hosts.
+      # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-affinity-options
+      #
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #       - matchExpressions:
+      #         - key: beta.kubernetes.io/instance-type
+      #           operator: In
+      #           # This should be adjusted to the instance type according to your setup
+      #           #
+      #           values:
+      #           - highio
+  # Volume Claim settings.
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
+  #
+  volumeClaimTemplates:
+  - metadata:
+      name: elasticsearch-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Ti
+      # Adjust to your storage class name
+      #
+      # storageClassName: local-storage
+- name: warm
+  count: 1
+  config:
+    node.roles: ["data_warm"]
+    # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+    # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+    # and leave node.store.allow_mmap unset.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+    #
+    node.store.allow_mmap: false
+  podTemplate:
+    spec:
+      containers:
+      - name: elasticsearch
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: 2
+      # Affinity/Anti-affinity settings for controlling the 'spreading' of Elasticsearch
+      # pods across existing hosts.
+      # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-affinity-options
+      #
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #       - matchExpressions:
+      #         - key: beta.kubernetes.io/instance-type
+      #           operator: In
+      #           # This should be adjusted to the instance type according to your setup
+      #           #
+      #           values:
+      #           - highstorage
+  # Volume Claim settings.
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
+  #
+  volumeClaimTemplates:
+  - metadata:
+      name: elasticsearch-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Ti
+      # Adjust to your storage class name
+      #
+      # storageClassName: local-storage
+- name: cold
+  count: 1
+  config:
+    node.roles: ["data_cold"]
+    # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+    # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+    # and leave node.store.allow_mmap unset.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+    #
+    node.store.allow_mmap: false
+  podTemplate:
+    spec:
+      containers:
+      - name: elasticsearch
+        resources:
+          limits:
+            memory: 8Gi
+            cpu: 2
+      # Affinity/Anti-affinity settings for controlling the 'spreading' of Elasticsearch
+      # pods across existing hosts.
+      # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-affinity-options
+      #
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #       - matchExpressions:
+      #         - key: beta.kubernetes.io/instance-type
+      #           operator: In
+      #           # This should be adjusted to the instance type according to your setup
+      #           #
+      #           values:
+      #           - highstorage
+  # Volume Claim settings.
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
+  #
+  volumeClaimTemplates:
+  - metadata:
+      name: elasticsearch-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 20Ti
+      # Adjust to your storage class name
+      #
+      # storageClassName: local-storage

--- a/addons/eck-stack/charts/eck-elasticsearch/examples/ingress/elasticsearch-ingress-aks.yaml
+++ b/addons/eck-stack/charts/eck-elasticsearch/examples/ingress/elasticsearch-ingress-aks.yaml
@@ -1,0 +1,26 @@
+---
+# The following is an example of an Elasticsearch resource that is configured to use an Ingress resource in an AKS cluster.
+#
+ingress:
+  enabled: true
+  className: webapprouting.kubernetes.azure.com
+  annotations:
+    # This is required for AKS Loadbalancing to understand that it's communicating with
+    # an HTTPS backend.
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+  labels:
+    my: label
+  pathType: Prefix
+  hosts:
+  - host: "elasticsearch.company.dev"
+  path: "/"
+nodeSets:
+- name: default
+  count: 3
+  # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+  # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+  # and leave node.store.allow_mmap unset.
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+  #
+  config:
+    node.store.allow_mmap: false

--- a/addons/eck-stack/charts/eck-elasticsearch/examples/ingress/elasticsearch-ingress-eks-alb.yaml
+++ b/addons/eck-stack/charts/eck-elasticsearch/examples/ingress/elasticsearch-ingress-eks-alb.yaml
@@ -1,0 +1,37 @@
+---
+# The following is an example of an Elasticsearch resource that is configured to use an Ingress resource in an EKS cluster
+# which provisions an application load balancer.
+#
+ingress:
+  enabled: true
+  className: alb
+  annotations:
+    alb.ingress.kubernetes.io/scheme: "internet-facing"
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    alb.ingress.kubernetes.io/target-type: "ip"
+    # To use an ALB with ECK, you must provide a valid ACM certificate ARN or use certificate discovery.
+    # There are 2 options for EKS:
+    # 1. Create a valid ACM certificate, and uncomment the following annotation and update it to the correct ARN.
+    # 2. Create a valid ACM certificate and ensure that the hosts[0].host matches the certificate's Common Name (CN) and
+    #    certificate discovery *should* find the certificate automatically and use it.
+    #
+    # ref: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.8/guide/ingress/cert_discovery/
+    #
+    # alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:00000000000:certificate/b65be571-8220-4f2e-8cb1-94194535d877"
+  labels:
+    my: label
+  pathType: Prefix
+  hosts:
+  - host: "elasticsearch.company.dev"
+  path: "/"
+nodeSets:
+- name: default
+  count: 3
+  # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+  # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+  # and leave node.store.allow_mmap unset.
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+  #
+  config:
+    node.store.allow_mmap: false

--- a/addons/eck-stack/charts/eck-elasticsearch/examples/ingress/elasticsearch-ingress-eks-nlb.yaml
+++ b/addons/eck-stack/charts/eck-elasticsearch/examples/ingress/elasticsearch-ingress-eks-nlb.yaml
@@ -1,0 +1,27 @@
+---
+# The following is an example of an Elasticsearch resource that is configured to deploy a
+# network load balancer (NLB) in an EKS cluster. To provision an NLB "ingress" for the
+# Elasticsearch cluster, you are required to set annotations on the service,
+# and not an Ingress resource.
+ingress:
+  enabled: false
+http:
+  service:
+    metadata:
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-type: external
+        service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+        service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+        service.beta.kubernetes.io/aws-load-balancer-backend-protocol: ssl
+    spec:
+      type: LoadBalancer
+nodeSets:
+- name: default
+  count: 3
+  # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+  # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+  # and leave node.store.allow_mmap unset.
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+  #
+  config:
+    node.store.allow_mmap: false

--- a/addons/eck-stack/charts/eck-elasticsearch/examples/ingress/elasticsearch-ingress-gke.yaml
+++ b/addons/eck-stack/charts/eck-elasticsearch/examples/ingress/elasticsearch-ingress-gke.yaml
@@ -1,0 +1,36 @@
+---
+# The following is an example of an Elasticsearch resource that is configured to use an Ingress resource in a GKE cluster.
+#
+ingress:
+  enabled: true
+  annotations:
+    my: annotation
+  labels:
+    my: label
+  pathType: Prefix
+  hosts:
+  - host: "elasticsearch.company.dev"
+    path: "/"
+http:
+  service:
+    metadata:
+      annotations:
+        # This is required for `ClusterIP` services (which are the default ECK service type) to be used with Ingress in GKE clusters.
+        cloud.google.com/neg: '{"ingress": true}'
+        # This is required to enable the GKE Ingress Controller to use HTTPS as the backend protocol.
+        cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+nodeSets:
+- name: default
+  count: 3
+  # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+  # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+  # and leave node.store.allow_mmap unset.
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+  #
+  config:
+    node.store.allow_mmap: false
+    # Enable anonymous access to allow GCLB health probes to succeed
+    xpack.security.authc:
+      anonymous:
+        username: anon
+        roles: monitoring_user

--- a/addons/eck-stack/charts/eck-elasticsearch/templates/NOTES.txt
+++ b/addons/eck-stack/charts/eck-elasticsearch/templates/NOTES.txt
@@ -1,0 +1,6 @@
+
+1. Check Elasticsearch resource status
+  $ kubectl get es {{ include "elasticsearch.fullname" . }} -n {{ .Release.Namespace }}
+
+2. Check Elasticsearch pod status
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l elasticsearch.k8s.elastic.co/cluster-name={{ include "elasticsearch.fullname" . }}

--- a/addons/eck-stack/charts/eck-elasticsearch/templates/_helpers.tpl
+++ b/addons/eck-stack/charts/eck-elasticsearch/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "elasticsearch.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "elasticsearch.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "elasticsearch.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "elasticsearch.labels" -}}
+helm.sh/chart: {{ include "elasticsearch.chart" . }}
+{{ include "elasticsearch.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "elasticsearch.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "elasticsearch.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-elasticsearch/templates/elasticsearch.yaml
+++ b/addons/eck-stack/charts/eck-elasticsearch/templates/elasticsearch.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: {{ include "elasticsearch.fullname" . }}
+  labels:
+    {{- include "elasticsearch.labels" . | nindent 4 }}
+  annotations:
+    eck.k8s.elastic.co/license: basic
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.auth }}
+  auth:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.secureSettings }}
+  secureSettings:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.transport }}
+  transport:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.http }}
+  http:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  version: {{ required "An Elasticsearch version is required" .Values.version }}
+  {{- with .Values.monitoring }}
+  monitoring:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.remoteClusters }}
+  remoteClusters:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.remoteClusterServer }}
+  remoteClusterServer:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.volumeClaimDeletePolicy }}
+  volumeClaimDeletePolicy:
+    {{- if and (not (eq . "DeleteOnScaledownOnly")) (not (eq . "DeleteOnScaledownAndClusterDeletion")) }}
+    {{ fail "volumeClaimDeletePolicy can only be one of 'DeleteOnScaledownOnly' or 'DeleteOnScaledownAndClusterDeletion'" }}
+    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if eq (len .Values.nodeSets) 0 }}
+  {{ fail "At least one nodeSet is required" }}
+  {{- end }}
+  nodeSets:
+    {{ toYaml .Values.nodeSets | nindent 4 }}
+  {{- with .Values.image }}
+  image: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget }}
+    {{- if .disabled }}
+  podDisruptionBudget: {}
+    {{- else }}
+      {{- with .spec }}
+  podDisruptionBudget:
+    spec:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- with .Values.serviceAccountName }}
+  serviceAccountName: {{ . }}
+  {{- end }}
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}

--- a/addons/eck-stack/charts/eck-elasticsearch/templates/ingress.yaml
+++ b/addons/eck-stack/charts/eck-elasticsearch/templates/ingress.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.ingress.enabled -}}
+{{- $pathType := .Values.ingress.pathType | default "Prefix" -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "elasticsearch.fullname" . }}
+  labels:
+    {{- include "elasticsearch.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.ingress.annotations }}
+  annotations:
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+  - hosts:
+  {{- range .Values.ingress.hosts }}
+    - {{ .host | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls.secretName }}
+    secretName: {{ .Values.ingress.tls.secretName }}
+  {{- else }}
+    secretName: {{ include "elasticsearch.fullname" . }}-es-http-certs-internal
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+  {{- $hostPath := .path | default "/" }}
+  - host: {{ .host | quote }}
+    http:
+      paths:
+      - path: {{ $hostPath }}
+        pathType: {{ $pathType }}
+        backend:
+          service:
+            name: {{ include "elasticsearch.fullname" $ }}-es-http
+            port:
+              number: 9200
+  {{- end }}
+{{ end }}

--- a/addons/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/addons/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -18,7 +18,8 @@
 
 # Version of Elasticsearch.
 #
-version: 9.1.0
+# version: 9.1.0
+version: 8.19.3
 
 # Elasticsearch Docker image to deploy
 #

--- a/addons/eck-stack/charts/eck-elasticsearch/values.yaml
+++ b/addons/eck-stack/charts/eck-elasticsearch/values.yaml
@@ -1,0 +1,393 @@
+---
+# Default values for eck-elasticsearch.
+# This is a YAML-formatted file.
+
+# Overridable names of the Elasticsearch resource.
+# By default, this is the Release name set for the chart,
+# followed by 'eck-elasticsearch'.
+#
+# nameOverride will override the name of the Chart with the name set here,
+# so nameOverride: quickstart, would convert to '{{ Release.name }}-quickstart'
+#
+# nameOverride: "quickstart"
+#
+# fullnameOverride will override both the release name, and the chart name,
+# and will name the Elasticsearch resource exactly as specified.
+#
+# fullnameOverride: "quickstart"
+
+# Version of Elasticsearch.
+#
+version: 9.1.0
+
+# Elasticsearch Docker image to deploy
+#
+# image:
+
+# Labels that will be applied to Elasticsearch.
+#
+labels: {}
+
+# Annotations that will be applied to Elasticsearch.
+#
+annotations: {}
+
+# Settings for configuring Elasticsearch users and roles.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-users-and-roles.html
+#
+auth: {}
+
+# Settings for configuring stack monitoring.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-stack-monitoring.html
+#
+monitoring: {}
+  # metrics:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
+  # logs:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
+
+# Control the Elasticsearch transport module used for internal communication between nodes.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-transport-settings.html
+#
+transport: {}
+  # service:
+  #   metadata:
+  #     labels:
+  #       my-custom: label
+  #   spec:
+  #     type: LoadBalancer
+  # tls:
+  #   subjectAltNames:
+  #     - ip: 1.2.3.4
+  #     - dns: hulk.example.com
+  #   certificate:
+  #     secretName: custom-ca
+
+# Settings to control how Elasticsearch will be accessed.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-accessing-elastic-services.html
+#
+http: {}
+  # service:
+  #   metadata:
+  #     labels:
+  #       my-custom: label
+  #   spec:
+  #     type: LoadBalancer
+  # tls:
+  #   selfSignedCertificate:
+  #     # To fully disable TLS for the HTTP layer of Elasticsearch, simply
+  #     # set the below field to 'true', removing all other fields.
+  #     disabled: false
+  #     subjectAltNames:
+  #       - ip: 1.2.3.4
+  #       - dns: hulk.example.com
+  #   certificate:
+  #     secretName: custom-ca
+
+# Control Elasticsearch Secure Settings.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-es-secure-settings.html#k8s-es-secure-settings
+#
+secureSettings: []
+  # - secretName: one-secure-settings-secret
+  # Projection of secret keys to specific paths
+  # - secretName: gcs-secure-settings
+  #   entries:
+  #   - key: gcs.client.default.credentials_file
+  #   - key: gcs_client_1
+  #     path: gcs.client.client_1.credentials_file
+  #   - key: gcs_client_2
+  #     path: gcs.client.client_2.credentials_file
+
+# Settings for limiting the number of simultaneous changes to an Elasticsearch resource.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-update-strategy.html
+#
+updateStrategy: {}
+  # changeBudget:
+  #   maxSurge: 3
+  #   maxUnavailable: 1
+
+# Controlling of connectivity between remote clusters within the same kubernetes cluster.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-remote-clusters.html
+#
+remoteClusters: {}
+  # - name: cluster-two
+  #   elasticsearchRef:
+  #     name: cluster-two
+  #     namespace: ns-two
+
+# RemoteClusterServer specifies if the remote cluster server should be enabled.
+# This must be enabled if this cluster is a remote cluster which is expected to be accessed using API key authentication.
+#
+remoteClusterServer: {}
+#   enabled: true
+
+# VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.
+# Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion.
+# By default, if not set or empty, the operator sets DeleteOnScaledownAndClusterDeletion.
+#
+volumeClaimDeletePolicy: ""
+
+# Settings to limit the disruption when pods need to be rescheduled for some reason such as upgrades or routine maintenance.
+# By default, if not set, the operator sets a budget that doesn't allow any pod to be removed in case the cluster is not green or if there is only one node of type `data` or `master`.
+# In all other cases the default PodDisruptionBudget sets `minUnavailable` equal to the total number of nodes minus 1.
+# To completely disable the pod disruption budget set `disabled` to true.
+#
+# podDisruptionBudget:
+#   spec:
+#     minAvailable: 2
+#     selector:
+#       matchLabels:
+#         elasticsearch.k8s.elastic.co/cluster-name: quickstart
+#   disabled: true
+
+# Used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
+# Can only be used if ECK is enforcing RBAC on references.
+#
+# serviceAccountName: ""
+
+# Number of revisions to retain to allow rollback in the underlying StatefulSets.
+# By default, if not set, Kubernetes sets 10.
+#
+# revisionHistoryLimit: 2
+
+# Node configuration settings.
+# The node roles which can be configured here are:
+# - "master"
+# - "data_hot"
+# - "data_cold"
+# - "data_frozen"
+# - "data_content"
+# - "ml"
+# - "ingest"
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-node-configuration.html
+#
+nodeSets:
+- name: default
+  count: 1
+  config:
+    # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+    # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+    # and leave node.store.allow_mmap unset.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+    #
+    node.store.allow_mmap: false
+  podTemplate:
+    # The following spec is exactly the Kubernetes Core V1 PodTemplateSpec. Any fields within the PodTemplateSpec
+    # are supported within the 'spec' field below.  Please see below documentation for the exhaustive list of fields.
+    #
+    # https://v1-24.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podtemplatespec-v1-core
+    #
+    # Only the commonly overridden/used fields will be noted below.
+    #
+    spec:
+
+      # If specified, the pod's scheduling constraints
+      # https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html
+      # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #       - matchExpressions:
+      #         - key: topology.kubernetes.io/zone
+      #           operator: In
+      #           values:
+      #           - antarctica-east1
+      #           - antarctica-west1
+
+      # Containers array.  Should only be used to customize the 'elasticsearch' container using the following fields.
+      containers:
+      - name: elasticsearch
+
+        # List of environment variables to set in the 'elasticsearch' container.
+        # https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+        # env:
+        # - name: "my-env-var"
+        #   value: "my-value"
+
+        # Compute Resources required by this container.
+        resources:
+          # Requests describes the minimum amount of compute resources required. If Requests is omitted for a container,
+          # it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value.
+          #
+          # Defaults used by the ECK Operator, if not specified, are below
+          limits:
+            # cpu: 1
+            memory: 2Gi
+          requests:
+            # cpu: 1
+            memory: 2Gi
+
+          # Example increasing both the requests and limits values:
+          # limits:
+          #   cpu: 4
+          #   memory: 8Gi
+          # requests:
+          #   cpu: 1
+          #   memory: 8Gi
+
+        # SecurityContext defines the security options the container should be run with.
+        # If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+        #
+        # These typically are set automatically by the ECK Operator, and should only be adjusted
+        # with the full knowledge of the effects of each field.
+        #
+        # securityContext:
+
+          # Whether this container has a read-only root filesystem. Default is false.
+          # readOnlyRootFilesystem: false
+
+          # The GID to run the entrypoint of the container process. Uses runtime default if unset.
+          # runAsGroup: 1000
+
+          # Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure
+          # that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed.
+          # runAsNonRoot: true
+
+          # The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified.
+          # runAsUser: 1000
+
+    # ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+    # https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+    # imagePullSecrets:
+    # - name: "image-pull-secret"
+
+    # List of initialization containers belonging to the pod.
+    #
+    # Common initContainers include setting sysctl, or in 7.x versions of Elasticsearch,
+    # installing Elasticsearch plugins.
+    #
+    # https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+    # initContainers:
+    # - command:
+    #   - sh
+    #   - "-c"
+    #   - sysctl -w vm.max_map_count=262144
+    #   name: sysctl
+    #   securityContext:
+    #     privileged: true
+    # - command:
+    #   - sh
+    #   - "-c"
+    #   - bin/elasticsearch-plugin remove --purge analysis-icu ; bin/elasticsearch-plugin install --batch analysis-icu
+    #   name: install-plugins
+    #   securityContext:
+    #     privileged: true
+
+
+    # NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node.
+    # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+    # https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html
+    # nodeSelector:
+    #   diskType: ssd
+    #   environment: production
+
+    # If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority.
+    # Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+    # priorityClassName: ""
+
+    # SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty. See type description for default values of each field.
+    # See previously defined 'securityContext' within 'podTemplate' for all available fields.
+    # securityContext: {}
+
+    # ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+    # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    # serviceAccountName: ""
+
+    # Optional duration in seconds to wait for the Elasticsearch pod to terminate gracefully.
+    # terminationGracePeriodSeconds: 30s
+
+    # If specified, the pod's tolerations that will apply to all containers within the pod.
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+    # tolerations:
+    # - key: "node-role.kubernetes.io/elasticsearch"
+    #   effect: "NoSchedule"
+    #   operator: "Exists"
+
+    # TopologySpreadConstraints describes how a group of pods ought to spread across topology domains.
+    # Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.
+    #
+    # These settings are generally applied within each `nodeSets[].podTemplate` field to apply to a specific Elasticsearch nodeset.
+    #
+    # https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html
+    # topologySpreadConstraints: {}
+
+    # List of volumes that can be mounted by containers belonging to the pod.
+    # https://kubernetes.io/docs/concepts/storage/volumes
+    # volumes: []
+
+# Settings for controlling Elasticsearch ingress. Enabling ingress will expose your Elasticsearch instance
+# to the public internet, and as such is disabled by default.
+#
+# Each Cloud Service Provider has different requirements for setting up Ingress. Some links to common documentation are:
+# - AWS:   https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html
+# - GCP:   https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
+# - Azure: https://learn.microsoft.com/en-us/azure/aks/app-routing
+# - Nginx: https://kubernetes.github.io/ingress-nginx/
+#
+ingress:
+  enabled: false
+
+  # Annotations that will be applied to the Ingress resource. Note that some ingress controllers are controlled via annotations.
+  # 
+  # Nginx Annotations: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/
+  #
+  # Common annotations:
+  #   kubernetes.io/ingress.class: gce          # Configures the Ingress resource to use the GCE ingress controller and create an external Application Load Balancer.
+  #   kubernetes.io/ingress.class: gce-internal # Configures the Ingress resource to use the GCE ingress controller and create an internal Application Load Balancer.
+  #   kubernetes.io/ingress.class: nginx        # Configures the Ingress resource to use the NGINX ingress controller.
+  #
+  annotations: {}
+
+  # Labels that will be applied to the Ingress resource.
+  #
+  labels: {}
+
+  # Some ingress controllers require the use of a specific class name to route traffic to the correct controller, notably AKS and EKS, which
+  # replaces the use of the 'kubernetes.io/ingress.class' annotation.
+  #
+  # className: webapprouting.kubernetes.azure.com | alb
+
+  # Ingress paths are required to have a corresponding path type. Defaults to 'Prefix'.
+  #
+  # There are 3 supported path types:
+  # - ImplementationSpecific
+  # - Prefix
+  # - Exact
+  #
+  # ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+  #
+  pathType: Prefix
+
+  # Hosts are a list of hosts included in the Ingress definition, with a corresponding path at which the default Elasticsearch service
+  # will be exposed. Each host in the list should be a fully qualified DNS name that will resolve to the exposed Ingress object.
+  #
+  # ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#name-based-virtual-hosting
+  #
+  hosts:
+    - host: chart-example.local
+      path: /
+
+  # TLS defines whether TLS will be enabled on the Ingress resource.
+  #
+  # *NOTE* Many Cloud Service Providers handle TLS in a custom manner, and as such, it is recommended to consult their documentation.
+  # Notably GKE and Nginx Ingress Controllers seems to respect the Ingress TLS settings, AKS and EKS ignore it.
+  #
+  # - AKS:   https://learn.microsoft.com/en-us/azure/aks/app-routing-dns-ssl
+  # - GKE:   https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#options_for_providing_ssl_certificates
+  # - EKS:   https://aws.amazon.com/blogs/containers/serve-distinct-domains-with-tls-powered-by-acm-on-amazon-eks/
+  # - Nginx: https://kubernetes.github.io/ingress-nginx/user-guide/tls/
+  #
+  # Kubernetes ingress TLS documentation:
+  # ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  #
+  tls:
+    enabled: false
+    # Optional Kubernetes secret name that contains a base64 encoded PEM certificate and private key that corresponds to the above 'hosts' definitions.
+    # If tls is enabled, but this field is not set, the self-signed certificate and key created by the ECK operator will be used.
+    # secretName: chart-example-tls

--- a/addons/eck-stack/charts/eck-enterprise-search/.helmignore
+++ b/addons/eck-stack/charts/eck-enterprise-search/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+templates/tests

--- a/addons/eck-stack/charts/eck-enterprise-search/Chart.yaml
+++ b/addons/eck-stack/charts/eck-enterprise-search/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+description: Elastic Enterprise Search managed by the ECK operator
+icon: https://github.com/elastic/ent-search/blob/main/public/app-search-favicon-196x196.png
+kubeVersion: '>= 1.21.0-0'
+name: eck-enterprise-search
+sources:
+- https://github.com/elastic/cloud-on-k8s
+type: application
+version: 0.16.0

--- a/addons/eck-stack/charts/eck-enterprise-search/examples/with-custom-configuration.yaml
+++ b/addons/eck-stack/charts/eck-enterprise-search/examples/with-custom-configuration.yaml
@@ -1,0 +1,19 @@
+config:
+  # define the exposed URL at which users will reach Enterprise Search
+  ent_search.external_url: https://my-custom-domain:3002
+  # define the exposed URL at which users will reach Kibana
+  kibana.host: https://kibana.my-custom-domain:5601
+  # configure app search document size limit
+  app_search.engine.document_size.limit: 100kb
+
+http:
+  service:
+    metadata:
+      labels:
+        my-custom: label
+  tls:
+    certificate:
+      secretName: my-cert
+
+elasticsearchRef:
+  name: eck-elasticsearch

--- a/addons/eck-stack/charts/eck-enterprise-search/templates/_helpers.tpl
+++ b/addons/eck-stack/charts/eck-enterprise-search/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "eck-enterprise-search.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "eck-enterprise-search.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "eck-enterprise-search.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "eck-enterprise-search.labels" -}}
+helm.sh/chart: {{ include "eck-enterprise-search.chart" . }}
+{{ include "eck-enterprise-search.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "eck-enterprise-search.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "eck-enterprise-search.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "eck-enterprise-search.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "eck-enterprise-search.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-enterprise-search/templates/enterprisesearch.yaml
+++ b/addons/eck-stack/charts/eck-enterprise-search/templates/enterprisesearch.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: enterprisesearch.k8s.elastic.co/v1
+kind: EnterpriseSearch
+metadata:
+  name: {{ include "eck-enterprise-search.fullname" . }}
+  labels:
+    {{- include "eck-enterprise-search.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    eck.k8s.elastic.co/license: basic
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  version: {{ required "An Enterprise Search version is required" .Values.version }}
+  count: {{ required "A pod count is required" .Values.count }}
+
+  {{- /*
+    This is complicated, but seems required to catch both the situations where the key does not exist (commented out), and the key exists but is an empty map.
+  */ -}}
+  {{- if and (or (and (hasKey .Values "configRef") (eq 0 (len .Values.configRef))) (not (hasKey .Values "configRef"))) (or (and (hasKey .Values "elasticsearchRef") (eq 0 (len .Values.elasticsearchRef))) (not (hasKey .Values "elasticsearchRef"))) }}
+  {{ fail "At least one of configRef or elasticsearchRef is required" }}
+  {{- end }}
+
+  {{- with .Values.image }}
+  image: {{ . }}
+  {{- end }}
+
+  {{- with .Values.serviceAccountName }}
+  serviceAccountName: {{ . }}
+  {{- end }}
+
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+
+  {{- with .Values.config }}
+  config:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.http }}
+  http:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.elasticsearchRef }}
+  elasticsearchRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.podTemplate }}
+  podTemplate:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.configRef }}
+  configRef:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/addons/eck-stack/charts/eck-enterprise-search/values.yaml
+++ b/addons/eck-stack/charts/eck-enterprise-search/values.yaml
@@ -1,0 +1,96 @@
+---
+# Default values for eck-enterprise-search.
+# This is a YAML-formatted file.
+
+# Overridable names of the Enterprise Search resource.
+# By default, this is the Release name set for the chart,
+# followed by 'eck-enterprise-search'.
+#
+# nameOverride will override the name of the Chart with the name set here,
+# so nameOverride: quickstart, would convert to '{{ Release.name }}-quickstart'
+#
+# nameOverride: "quickstart"
+#
+# fullnameOverride will override both the release name, and the chart name,
+# and will name the Enterprise Search resource exactly as specified.
+#
+# fullnameOverride: "quickstart"
+
+# Version of Enterprise Search.
+#
+version: 8.19.0
+
+# Enterprise Search Docker image to deploy
+#
+# image:
+
+# Used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
+# Can only be used if ECK is enforcing RBAC on references.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-restrict-cross-namespace-associations.html
+#
+# serviceAccountName: ""
+
+# Labels that will be applied to Enterprise Search.
+#
+labels: {}
+
+# Annotations that will be applied to Enterprise Search.
+#
+annotations: {}
+
+# Count of Enterprise Search replicas to create.
+#
+count: 1
+
+# The Enterprise Search configuration, the ECK equivalent to enterprise-search.yml
+# ref: https://www.elastic.co/guide/en/enterprise-search/current/configuration.html#configuration-configure
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-enterprise-search-configuration.html
+#
+# At a minimum, you must specify the external URL and Kibana host.
+#
+config: {}
+  # define the exposed URL at which users will reach Enterprise Search
+  # ent_search.external_url: https://my-custom-domain:3002
+  # define the exposed URL at which users will reach Kibana
+  # kibana.host: https://kibana.my-custom-domain:5601
+
+# Settings to control how Enterprise Search will be accessed.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-accessing-elastic-services.html
+#
+http: {}
+  # tls:
+  #   certificate:
+  #     secretName: my-cert
+  # service:
+  #   metadata:
+  #     labels:
+  #       my-custom: label
+
+# Reference to ECK-managed Elasticsearch resource.
+#
+elasticsearchRef: {}
+  # name: eck-elasticsearch
+  # Optional namespace reference to Elasticsearch resource.
+  # If not specified, then the namespace of the Enterprise Search resource
+  # will be assumed.
+  #
+  # namespace: default
+
+# Set podTemplate to customize the pod used by Enterprise Search
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-customize-pods.html
+#
+podTemplate: {}
+
+# Number of revisions to retain to allow rollback in the underlying Deployment.
+# If not set Kubernetes sets this to 10 by default.
+#
+# revisionHistoryLimit: 2
+
+# If you would prefer your sensitive data to be stored in a Secret, you can specify the name of the Secret reference.
+# In addition, if you do not want to use the `elasticsearchRef` mechanism or if you want to connect to an Elasticsearch
+# cluster not managed by ECK, you can manually configure Enterprise Search to access any available Elasticsearch cluster:
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-enterprise-search-configuration.html#k8s-enterprise-search-secret-configuration
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-enterprise-search-configuration.html#k8s-enterprise-search-connect-non-eck-es
+#
+configRef: {}
+  # secretName: enterprise-search-config

--- a/addons/eck-stack/charts/eck-fleet-server/.helmignore
+++ b/addons/eck-stack/charts/eck-fleet-server/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+templates/tests

--- a/addons/eck-stack/charts/eck-fleet-server/Chart.yaml
+++ b/addons/eck-stack/charts/eck-fleet-server/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+description: Elastic Fleet Server as an Agent managed by the ECK operator
+kubeVersion: '>= 1.21.0-0'
+name: eck-fleet-server
+sources:
+- https://github.com/elastic/cloud-on-k8s
+- https://github.com/elastic/elastic-agent
+- https://github.com/elastic/fleet-server
+- https://www.elastic.co/guide/en/fleet/current/fleet-overview.html
+type: application
+version: 0.16.0

--- a/addons/eck-stack/charts/eck-fleet-server/LICENSE
+++ b/addons/eck-stack/charts/eck-fleet-server/LICENSE
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/addons/eck-stack/charts/eck-fleet-server/examples/fleet-server.yaml
+++ b/addons/eck-stack/charts/eck-fleet-server/examples/fleet-server.yaml
@@ -1,0 +1,17 @@
+version: 9.1.0
+deployment:
+  replicas: 1
+  podTemplate:
+    spec:
+      serviceAccountName: fleet-server
+      automountServiceAccountToken: true
+elasticsearchRefs:
+- name: eck-elasticsearch
+kibanaRef:
+  name: eck-kibana
+http:
+  service:
+    spec:
+      type: ClusterIP
+serviceAccount:
+  name: fleet-server

--- a/addons/eck-stack/charts/eck-fleet-server/templates/NOTES.txt
+++ b/addons/eck-stack/charts/eck-fleet-server/templates/NOTES.txt
@@ -1,0 +1,6 @@
+
+1. Check Fleet Server status
+  $ kubectl get agent {{ include "fleet-server.fullname" . }} -n {{ .Release.Namespace }}
+
+2. Check Fleet Server pod status
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l fleet-server.k8s.elastic.co/name={{ include "fleet-server.fullname" . }}

--- a/addons/eck-stack/charts/eck-fleet-server/templates/_helpers.tpl
+++ b/addons/eck-stack/charts/eck-fleet-server/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fleet-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fleet-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fleet-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "fleet-server.labels" -}}
+helm.sh/chart: {{ include "fleet-server.chart" . }}
+{{ include "fleet-server.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fleet-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fleet-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-fleet-server/templates/cluster-role-binding.yaml
+++ b/addons/eck-stack/charts/eck-fleet-server/templates/cluster-role-binding.yaml
@@ -1,0 +1,33 @@
+{{- with .Values.clusterRoleBinding }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "fleet-server.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or $.Values.annotations .annotations }}
+  annotations:
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- with .subjects }}
+subjects:
+{{- range . }}
+  - kind: {{ .kind }}
+    name: {{ .name }}
+    namespace: {{ .namespace | default $.Release.Namespace | quote }}
+{{- end }}
+{{- end }}
+roleRef:
+  kind: {{ .roleRef.kind }}
+  name: {{ .roleRef.name }}
+  apiGroup: {{ .roleRef.apiGroup }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-fleet-server/templates/cluster-role.yaml
+++ b/addons/eck-stack/charts/eck-fleet-server/templates/cluster-role.yaml
@@ -1,0 +1,22 @@
+{{- with .Values.clusterRole }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "fleet-server.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or $.Values.annotations .annotations }}
+  annotations:
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+rules: {{- toYaml .rules | nindent 2 }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
+++ b/addons/eck-stack/charts/eck-fleet-server/templates/fleet-server.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: {{ include "fleet-server.fullname" . }}
+  labels:
+    {{- include "fleet-server.labels" . | nindent 4 }}
+  annotations:
+    eck.k8s.elastic.co/license: basic
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  version: {{ required "A Fleet Server version is required" (or ((.Values.spec).version) (.Values.version)) }}
+  mode: fleet
+  fleetServerEnabled: true
+  {{- if (or (hasKey (.Values.spec) "mode") (hasKey .Values "mode")) }}
+  {{- fail "mode cannot be changed" }}
+  {{- end }}
+  {{- if (or (hasKey (.Values.spec) "fleetServerEnabled") (hasKey .Values "fleetServerEnabled"))}}
+  {{- fail "fleetServerEnabled cannot be changed" }}
+  {{- end }}
+
+  {{- $statefulSet := (or (hasKey (.Values.spec) "statefulSet") (hasKey .Values "statefulSet")) }}
+  {{- $deployment := (or (hasKey (.Values.spec) "deployment") (hasKey .Values "deployment")) }}
+  {{- if and (not $statefulSet) (not $deployment) }}
+  {{ fail "At least one of statefulSet or deployment is required" }}
+  {{- end }}
+  {{- if $statefulSet }}
+  {{- $ss := or ((.Values.spec).statefulSet) (.Values.statefulSet) }}
+  statefulSet:
+    {{- /* This is required to render the empty statefulSet ( {} ) properly */}}
+    {{- $ss | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $deployment }}
+  {{- $deploy := or ((.Values.spec).deployment) (.Values.deployment) }}
+  deployment:
+    {{- /* This is required to render the empty deployment ( {} ) properly */}}
+    {{- $deploy | default dict | toYaml | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).image) (.Values.image) }}
+  image: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).elasticsearchRefs) (.Values.elasticsearchRefs) }}
+  elasticsearchRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).kibanaRef) (.Values.kibanaRef) }}
+  kibanaRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).policyID) (.Values.policyID) }}
+  policyID: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).http) (.Values.http) }}
+  http:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).revisionHistoryLimit) (.Values.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with or (((.Values.spec).serviceAccount).name) ((.Values.serviceAccount).name) }}
+  serviceAccountName: {{ . }}
+  {{- end }}

--- a/addons/eck-stack/charts/eck-fleet-server/templates/service-account.yaml
+++ b/addons/eck-stack/charts/eck-fleet-server/templates/service-account.yaml
@@ -1,0 +1,22 @@
+{{- with .Values.serviceAccount }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace | default $.Release.Namespace | quote }}
+  labels:
+    {{- include "fleet-server.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or $.Values.annotations .annotations }}
+  annotations:
+    {{- with $.Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-fleet-server/values.yaml
+++ b/addons/eck-stack/charts/eck-fleet-server/values.yaml
@@ -1,0 +1,157 @@
+---
+# Default values for eck-fleet-server.
+# This is a YAML-formatted file.
+
+# Overridable names of the Fleet Server resource.
+# By default, this is the Release name set for the chart,
+# followed by 'eck-fleet-server'.
+#
+# nameOverride will override the name of the Chart with the name set here,
+# so nameOverride: quickstart, would convert to '{{ Release.name }}-quickstart'
+#
+# nameOverride: "quickstart"
+#
+# fullnameOverride will override both the release name, and the chart name,
+# and will name the Fleet Server resource exactly as specified.
+#
+# fullnameOverride: "quickstart"
+
+# Version of Elastic Fleet Server.
+#
+version: 9.1.0
+
+# Labels that will be applied to Elastic Fleet Server.
+#
+labels: {}
+
+# Annotations that will be applied to Elastic Fleet Server.
+#
+annotations: {}
+
+# Elastic Fleet Server Agent image to deploy.
+#
+# image: docker.elastic.co/beats/elastic-agent:9.1.0
+
+# ** Deprecation Notice **
+# The previous versions of this Helm Chart simply used the `spec` field here
+# and allowed the user to specify any fields below `spec` that were templated directly
+# into the final Agent/Fleet Server manifest. This is no longer the preferred way to specify these
+# fields and each field that is supported underneath `spec` is now directly specified
+# in this values file. Currently both patterns are supported for backwards compatibility
+# but we plan to remove the `spec` field in the future.
+# spec: {}
+
+# Referenced resources are below and both elasticsearchRefs and kibanaRef are required for a functional Fleet Server.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-setting-referenced-resources
+#
+# Reference to ECK-managed Kibana instance.
+# This is required for Fleet Server.
+#
+# kibanaRef:
+#   name: quickstart
+  # Optional namespace reference to Kibana instance.
+  # If not specified, then the namespace of the Fleet Server resource
+  # will be assumed.
+  #
+  # namespace: default
+
+# Reference to ECK-managed Elasticsearch instance.
+# This is required for Fleet Server.
+#
+elasticsearchRefs: []
+# - name: eck-elasticsearch
+  # Optional namespace reference to Elasticsearch instance.
+  # If not specified, then the namespace of the Fleet Server resource
+  # will be assumed.
+  #
+  # namespace: default
+
+# policyID determines into which Agent Policy this Fleet Server will be enrolled.
+policyID: eck-fleet-server
+
+# The HTTP layer configuration for the Fleet Server Service.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-customize-fleet-server-service
+#
+# http:
+
+# Deployment or StatefulSet specification for Fleet Server.
+# At least one is required of [deployment, statefulSet].
+# No default is currently set, refer to https://github.com/elastic/cloud-on-k8s/issues/7429.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-chose-the-deployment-model
+#
+# deployment:
+#   replicas: 1
+#   podTemplate:
+#     spec:
+#       serviceAccountName: fleet-server
+#       automountServiceAccountToken: true
+#
+# statefulSet:
+#   podTemplate:
+#     spec:
+#       serviceAccountName: fleet-server
+#       automountServiceAccountToken: true
+
+# Number of revisions to retain to allow rollback in the underlying Deployment.
+# If not set Kubernetes sets this to 10 by default.
+#
+# revisionHistoryLimit: 2
+
+# ServiceAccount to be used by Elastic Fleet Server. Some Fleet Server features (such as autodiscover or Kubernetes module metricsets)
+# require that Fleet Server Pods interact with Kubernetes APIs. This functionality requires specific permissions
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-role-based-access-control
+#
+serviceAccount:
+  name: fleet-server
+  # namespace: optional-namespace
+
+# ClusterRoleBinding to be used by Elastic Fleet Server. Similar to ServiceAccount, this is required in some scenarios.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-role-based-access-control
+#
+clusterRoleBinding:
+  name: fleet-server
+  subjects:
+  - kind: ServiceAccount
+    name: fleet-server
+    # namespace: default
+  roleRef:
+    kind: ClusterRole
+    name: fleet-server
+    apiGroup: rbac.authorization.k8s.io
+
+# ClusterRole to be used by Elastic Fleet Server. Similar to ServiceAccount, this is required in some scenarios.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-elastic-agent-fleet-configuration.html#k8s-elastic-agent-fleet-configuration-role-based-access-control
+#
+clusterRole:
+  name: fleet-server
+  rules:
+  - apiGroups: [""]
+    resources:
+    - pods
+    - namespaces
+    - nodes
+    verbs:
+    - get
+    - watch
+    - list
+  - apiGroups: ["apps"]
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups: ["coordination.k8s.io"]
+    resources:
+    - leases
+    verbs:
+    - get
+    - create
+    - update

--- a/addons/eck-stack/charts/eck-kibana/.helmignore
+++ b/addons/eck-stack/charts/eck-kibana/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+templates/tests

--- a/addons/eck-stack/charts/eck-kibana/Chart.yaml
+++ b/addons/eck-stack/charts/eck-kibana/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+description: Kibana managed by the ECK operator
+icon: https://helm.elastic.co/icons/kibana.png
+kubeVersion: '>= 1.21.0-0'
+name: eck-kibana
+sources:
+- https://github.com/elastic/cloud-on-k8s
+- https://github.com/elastic/kibana
+type: application
+version: 0.16.0

--- a/addons/eck-stack/charts/eck-kibana/LICENSE
+++ b/addons/eck-stack/charts/eck-kibana/LICENSE
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/addons/eck-stack/charts/eck-kibana/examples/http-configuration.yaml
+++ b/addons/eck-stack/charts/eck-kibana/examples/http-configuration.yaml
@@ -1,0 +1,36 @@
+---
+# Version of Kibana.
+#
+version: 9.1.0
+
+# Labels that will be applied to Kibana.
+#
+labels: {}
+  # key: value
+
+# Annotations that will be applied to Kibana.
+#
+annotations: {}
+  # key: value
+
+# Count of Kibana replicas to create.
+#
+count: 1
+
+# Reference to ECK-managed Elasticsearch resource, ideally from {{ "elasticsearch.fullname" }}
+#
+elasticsearchRef:
+  name: eck-elasticsearch
+  # namespace: default
+http:
+  service:
+    spec:
+      # Type of service to deploy for Kibana.
+      # This deploys a load balancer in a cloud service provider, where supported.
+      #
+      type: LoadBalancer
+  # tls:
+  #   selfSignedCertificate:
+  #     subjectAltNames:
+  #     - ip: 1.2.3.4
+  #     - dns: kibana.example.com

--- a/addons/eck-stack/charts/eck-kibana/examples/ingress/kibana-aks.yaml
+++ b/addons/eck-stack/charts/eck-kibana/examples/ingress/kibana-aks.yaml
@@ -1,0 +1,28 @@
+# The following is an example of a Kibana resource that is configured to use an Ingress resource in an AKS cluster.
+#
+
+# Name of the Kibana instance.
+#
+fullnameOverride: kibana
+
+# Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
+#
+elasticsearchRef:
+  name: elasticsearch
+config:
+  server:
+    publicBaseUrl: "https://kibana.company.dev"
+
+ingress:
+  enabled: true
+  className: webapprouting.kubernetes.azure.com
+  annotations:
+    # This is required for AKS Loadbalancing to understand that it's communicating with
+    # an HTTPS backend.
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+  labels:
+    my: label
+  pathType: Prefix
+  hosts:
+  - host: "kibana.company.dev"
+  path: "/"

--- a/addons/eck-stack/charts/eck-kibana/examples/ingress/kibana-eks.yaml
+++ b/addons/eck-stack/charts/eck-kibana/examples/ingress/kibana-eks.yaml
@@ -1,0 +1,48 @@
+# The following is an example of a Kibana resource that is configured to use an Ingress resource in an EKS cluster.
+#
+
+# Name of the Kibana instance.
+#
+fullnameOverride: kibana
+
+# Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
+#
+elasticsearchRef:
+  name: elasticsearch
+config:
+  server:
+    publicBaseUrl: "https://kibana.company.dev"
+
+ingress:
+  enabled: true
+  className: alb
+  annotations:
+    alb.ingress.kubernetes.io/scheme: "internet-facing"
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    alb.ingress.kubernetes.io/target-type: "ip"
+    # To use an ALB with ECK, you must provide a valid ACM certificate ARN or use certificate discovery.
+    # There are 2 options for EKS:
+    # 1. Create a valid ACM certificate, and uncomment the following annotation and update it to the correct ARN.
+    # 2. Create a valid ACM certificate and ensure that the hosts[0].host matches the certificate's Common Name (CN) and
+    #    certificate discovery *should* find the certificate automatically and use it.
+    #
+    # ref: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.8/guide/ingress/cert_discovery/
+    #
+    # alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:00000000000:certificate/b65be571-8220-4f2e-8cb1-94194535d877"
+  labels:
+    my: label
+  pathType: Prefix
+  hosts:
+  - host: "kibana.company.dev"
+  path: "/"
+nodeSets:
+- name: default
+  count: 3
+  # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+  # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+  # and leave node.store.allow_mmap unset.
+  # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+  #
+  config:
+    node.store.allow_mmap: false

--- a/addons/eck-stack/charts/eck-kibana/examples/ingress/kibana-gke.yaml
+++ b/addons/eck-stack/charts/eck-kibana/examples/ingress/kibana-gke.yaml
@@ -1,0 +1,31 @@
+# The following is an example of a Kibana resource that is configured to use an Ingress resource in a GKE cluster.
+#
+
+# Name of the Kibana instance.
+#
+fullnameOverride: kibana
+
+# Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
+#
+elasticsearchRef:
+  name: elasticsearch
+config:
+  server:
+    publicBaseUrl: "https://kibana.company.dev"
+http:
+  service:
+    metadata:
+      annotations:
+        # This is required for `ClusterIP` services (which are the default ECK service type) to be used with Ingress in GKE clusters.
+        cloud.google.com/neg: '{"ingress": true}'
+        # This is required to enable the GKE Ingress Controller to use HTTPS as the backend protocol.
+        cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+
+ingress:
+  enabled: true
+  pathType: Prefix
+  hosts:
+  - host: "kibana.company.dev"
+    path: "/"
+  tls:
+    enabled: true

--- a/addons/eck-stack/charts/eck-kibana/templates/NOTES.txt
+++ b/addons/eck-stack/charts/eck-kibana/templates/NOTES.txt
@@ -1,0 +1,6 @@
+
+1. Check Kibana status
+  $ kubectl get kibana {{ include "kibana.fullname" . }} -n {{ .Release.Namespace }}
+
+2. Check Kibana pod status
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l kibana.k8s.elastic.co/name={{ include "kibana.fullname" . }}

--- a/addons/eck-stack/charts/eck-kibana/templates/_helpers.tpl
+++ b/addons/eck-stack/charts/eck-kibana/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kibana.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kibana.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kibana.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kibana.labels" -}}
+helm.sh/chart: {{ include "kibana.chart" . }}
+{{ include "kibana.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kibana.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kibana.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-kibana/templates/ingress.yaml
+++ b/addons/eck-stack/charts/eck-kibana/templates/ingress.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.ingress.enabled -}}
+{{- $pathType := .Values.ingress.pathType | default "Prefix" -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "kibana.fullname" . }}
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.ingress.annotations }}
+  annotations:
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+  - hosts:
+  {{- range .Values.ingress.hosts }}
+    - {{ .host | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls.secretName }}
+    secretName: {{ .Values.ingress.tls.secretName }}
+  {{- else }}
+    secretName: {{ include "kibana.fullname" . }}-kb-http-certs-internal
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+  {{- $hostPath := .path | default "/" }}
+  - host: {{ .host | quote }}
+    http:
+      paths:
+      - path: {{ $hostPath }}
+        pathType: {{ $pathType }}
+        backend:
+          service:
+            name: {{ include "kibana.fullname" $ }}-kb-http
+            port:
+              number: 5601
+  {{- end }}
+{{ end }}

--- a/addons/eck-stack/charts/eck-kibana/templates/kibana.yaml
+++ b/addons/eck-stack/charts/eck-kibana/templates/kibana.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: {{ include "kibana.fullname" . }}
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+  annotations:
+    eck.k8s.elastic.co/license: basic
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  version: {{ required "A Kibana version is required" .Values.version }}
+  {{- /* 
+    The following templates with 'or' are to allow both .spec.field and .field to be set for backwards 
+    compatibility purposes. See https://github.com/elastic/cloud-on-k8s/pull/8192 for details.
+  */ -}}
+  {{- with or ((.Values.spec).image) (.Values.image) }}
+  image: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).count) (.Values.count) }}
+  count: {{ . }}
+  {{- end }}
+  {{- $esRef := or ((.Values.spec).elasticsearchRef) (.Values.elasticsearchRef) }}
+  {{- if not ($esRef).name }}
+  {{ fail "An elasticsearchRef is required" }}
+  {{- end }}
+  elasticsearchRef:
+  {{- toYaml $esRef | nindent 4 }}
+  {{- $entsearchRef := or ((.Values.spec).enterpriseSearchRef) (.Values.enterpriseSearchRef) }}
+  {{- if $entsearchRef }}
+  enterpriseSearchRef:
+  {{- toYaml $entsearchRef | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).config) (.Values.config) }}
+  config:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).http) (.Values.http) }}
+  http:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).podTemplate) (.Values.podTemplate) }}
+  podTemplate:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).revisionHistoryLimit) (.Values.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).secureSettings) (.Values.secureSettings) }}
+  secureSettings:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with or ((.Values.spec).serviceAccountName) (.Values.serviceAccountName) }}
+  serviceAccountName: {{ . }}
+  {{- end }}
+  {{- with or ((.Values.spec).monitoring) (.Values.monitoring) }}
+  monitoring:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/addons/eck-stack/charts/eck-kibana/values.yaml
+++ b/addons/eck-stack/charts/eck-kibana/values.yaml
@@ -1,0 +1,179 @@
+---
+# Default values for eck-kibana.
+# This is a YAML-formatted file.
+
+# Overridable names of the Kibana resource.
+# By default, this is the Release name set for the chart,
+# followed by 'eck-kibana'.
+#
+# nameOverride will override the name of the Chart with the name set here,
+# so nameOverride: quickstart, would convert to '{{ Release.name }}-quickstart'
+#
+# nameOverride: "quickstart"
+#
+# fullnameOverride will override both the release name, and the chart name,
+# and will name the Kibana resource exactly as specified.
+#
+# fullnameOverride: "quickstart"
+
+# Version of Kibana.
+#
+version: 9.1.0
+
+# Kibana Docker image to deploy
+#
+# image: docker.elastic.co/kibana/kibana:9.1.0
+
+# Labels that will be applied to Kibana.
+#
+labels: {}
+
+# Annotations that will be applied to Kibana.
+#
+annotations: {}
+
+# ** Deprecation Notice **
+# The previous versions of this Helm Chart simply used the `spec` field here
+# and allowed the user to specify any fields below spec that were templated directly
+# into the final Kibana manifest. This is no long the preferred way to specify these
+# fields and each field that is supported underneath `spec` is now directly specified
+# in this values file. Currently both patterns are supported for backwards compatibility
+# but we plan to remove the `spec` field in the future.
+# spec: {}
+
+# Count of Kibana replicas to create.
+#
+count: 1
+
+# Reference to ECK-managed Elasticsearch resource.
+#
+elasticsearchRef: {}
+  # name: eck-elasticsearch
+  # Optional namespace reference to Elasticsearch resource.
+  # If not specified, then the namespace of the Kibana resource
+  # will be assumed.
+  #
+  # namespace: default
+
+# Reference to an EnterpriseSearch running in the same Kubernetes cluster
+#
+# enterpriseSearchRef:
+
+# The Kibana configuration (kibana.yml)
+# ref: https://www.elastic.co/guide/en/kibana/current/settings.html
+#
+config: null
+
+# The HTTP layer configuration for Kibana.
+#
+# http:
+
+# PodTemplate provides customisation options (labels, annotations, affinity rules,
+# resource requests, and so on) for the Kibana pods
+#
+# podTemplate:
+
+# Number of revisions to retain to allow rollback in the underlying deployment.
+# By default, if not set, Kubernetes sets 10.
+#
+# revisionHistoryLimit: 2
+
+# Control Kibana Secure Settings.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana-secure-settings.html
+#
+secureSettings: []
+
+# Used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
+# Can only be used if ECK is enforcing RBAC on references.
+#
+# serviceAccountName: ""
+
+# Settings for configuring stack monitoring.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-stack-monitoring.html
+#
+monitoring: {}
+  # metrics:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
+  # logs:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
+
+# Settings for controlling Kibana ingress. Enabling ingress will expose your Kibana instance
+# to the public internet, and as such is disabled by default.
+#
+# *NOTE* when configuring Kibana Ingress, ensure that `config.server.publicBaseUrl` setting for
+# Kibana is also set, as it is required when exposing Kibana behind a load balancer/ingress.
+# Also of note are `server.basePath`, and `server.rewriteBasePath` settings in the Kibana configuration.
+#
+# ref: https://www.elastic.co/guide/en/kibana/current/settings.html
+#
+# Each Cloud Service Provider has different requirements for setting up Ingress. Some links to common documentation are:
+# - AWS: https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html
+# - GCP: https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
+# - Azure: https://learn.microsoft.com/en-us/azure/aks/app-routing
+# - Nginx: https://kubernetes.github.io/ingress-nginx/
+#
+ingress:
+  enabled: false
+
+  # Annotations that will be applied to the Ingress resource. Note that some ingress controllers are controlled via annotations.
+  #
+  # Nginx Annotations: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/
+  #
+  # Common annotations:
+  #   kubernetes.io/ingress.class: gce          # Configures the Ingress resource to use the GCE ingress controller and create an external Application Load Balancer.
+  #   kubernetes.io/ingress.class: gce-internal # Configures the Ingress resource to use the GCE ingress controller and create an internal Application Load Balancer.
+  #   kubernetes.io/ingress.class: nginx        # Configures the Ingress resource to use the NGINX ingress controller.
+  #
+  annotations: {}
+
+  # Labels that will be applied to the Ingress resource.
+  #
+  labels: {}
+
+  # Some ingress controllers require the use of a specific class name to route traffic to the correct controller, notably AKS and EKS, which
+  # replaces the use of the 'kubernetes.io/ingress.class' annotation.
+  #
+  # className: webapprouting.kubernetes.azure.com | alb
+
+  # Ingress paths are required to have a corresponding path type. Defaults to 'Prefix'.
+  #
+  # There are 3 supported path types:
+  # - ImplementationSpecific
+  # - Prefix
+  # - Exact
+  #
+  # ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+  #
+  pathType: Prefix
+
+  # Hosts are a list of hosts included in the Ingress definition, with a corresponding path at which the Kibana service
+  # will be exposed. Each host in the list should be a fully qualified DNS name that will resolve to the exposed Ingress object.
+  #
+  # ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#name-based-virtual-hosting
+  #
+  hosts:
+    - host: chart-example.local
+      path: /
+
+  # TLS defines whether TLS will be enabled on the Ingress resource.
+  #
+  # *NOTE* Many Cloud Service Providers handle TLS in a custom manner, and as such, it is recommended to consult their documentation.
+  # Notably GKE and Nginx Ingress Controllers seems to respect the Ingress TLS settings, AKS and EKS ignore it.
+  #
+  # - AKS:   https://learn.microsoft.com/en-us/azure/aks/app-routing-dns-ssl
+  # - GKE:   https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#options_for_providing_ssl_certificates
+  # - EKS:   https://aws.amazon.com/blogs/containers/serve-distinct-domains-with-tls-powered-by-acm-on-amazon-eks/
+  # - Nginx: https://kubernetes.github.io/ingress-nginx/user-guide/tls/
+  #
+  # Kubernetes ingress TLS documentation:
+  # ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  #
+  tls:
+    enabled: false
+    # Optional Kubernetes secret name that contains a base64 encoded PEM certificate and private key that corresponds to the above 'hosts' definitions.
+    # If tls is enabled, but this field is not set, the self-signed certificate and key created by the ECK operator will be used.
+    # secretName: chart-example-tls

--- a/addons/eck-stack/charts/eck-logstash/.helmignore
+++ b/addons/eck-stack/charts/eck-logstash/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+templates/tests

--- a/addons/eck-stack/charts/eck-logstash/Chart.yaml
+++ b/addons/eck-stack/charts/eck-logstash/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+description: Logstash managed by the ECK operator
+icon: https://helm.elastic.co/icons/logstash.png
+kubeVersion: '>= 1.21.0-0'
+name: eck-logstash
+sources:
+- https://github.com/elastic/cloud-on-k8s
+- https://github.com/elastic/logstash
+type: application
+version: 0.16.0

--- a/addons/eck-stack/charts/eck-logstash/LICENSE
+++ b/addons/eck-stack/charts/eck-logstash/LICENSE
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/addons/eck-stack/charts/eck-logstash/examples/basic-eck.yaml
+++ b/addons/eck-stack/charts/eck-logstash/examples/basic-eck.yaml
@@ -1,0 +1,44 @@
+---
+# values corresponding to config/recipes/logstash/logstash-eck.yaml
+version: 9.1.0
+
+elasticsearchRefs:
+  - clusterName: eck
+    name: elasticsearch
+
+pipelines:
+  - pipeline.id: main
+    config.string: |
+      input {
+        beats {
+          port => 5044
+        }
+      }
+      filter {
+        grok {
+          match => { "message" => "%{HTTPD_COMMONLOG}"}
+        }
+        geoip {
+          source => "[source][address]"
+          target => "[source]"
+        }
+      }
+      output {
+        elasticsearch {
+          hosts => [ "${ECK_ES_HOSTS}" ]
+          user => "${ECK_ES_USER}"
+          password => "${ECK_ES_PASSWORD}"
+          ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+        }
+      }
+
+services:
+  - name: beats
+    service:
+      spec:
+        type: ClusterIP
+        ports:
+          - port: 5044
+            name: "filebeat"
+            protocol: TCP
+            targetPort: 5044

--- a/addons/eck-stack/charts/eck-logstash/examples/es-role.yaml
+++ b/addons/eck-stack/charts/eck-logstash/examples/es-role.yaml
@@ -1,0 +1,25 @@
+---
+# values corresponding to config/recipes/logstash/logstash-es-role.yaml
+version: 9.1.0
+
+elasticsearchRefs:
+  - clusterName: eck
+    name: elasticsearch
+
+pipelines:
+  - pipeline.id: main
+    config.string: |
+      input { exec { command => "uptime" interval => 10 } } 
+      output { 
+        elasticsearch {
+          hosts => [ "${ECK_ES_HOSTS}" ]
+          ssl_enabled => true
+          ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+          user => "${ECK_ES_USER}"
+          password => "${ECK_ES_PASSWORD}"
+          index => "my-index"
+          data_stream => false
+          ilm_enabled => false
+          manage_template => false
+        } 
+      }

--- a/addons/eck-stack/charts/eck-logstash/examples/monitored.yaml
+++ b/addons/eck-stack/charts/eck-logstash/examples/monitored.yaml
@@ -1,0 +1,49 @@
+---
+# values corresponding to config/recipes/logstash/logstash-monitored.yaml
+version: 9.1.0
+
+monitoring:
+  metrics:
+    elasticsearchRefs:
+      - name: elasticsearch-monitoring
+
+pipelines:
+  - pipeline.id: main
+    config.string: |
+      input {
+        beats {
+          port => 5044
+        }
+      }
+      filter {
+        grok {
+          match => { "message" => "%{HTTPD_COMMONLOG}"}
+        }
+        geoip {
+          source => "[source][address]"
+          target => "[source]"
+        }
+      }
+      output {
+        elasticsearch {
+          hosts => [ "${ECK_ES_HOSTS}" ]
+          user => "${ECK_ES_USER}"
+          password => "${ECK_ES_PASSWORD}"
+          ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+        }
+      }
+
+elasticsearchRefs:
+  - clusterName: eck
+    name: elasticsearch
+
+services:
+  - name: beats
+    service:
+      spec:
+        type: ClusterIP
+        ports:
+          - port: 5044
+            name: "filebeat"
+            protocol: TCP
+            targetPort: 5044

--- a/addons/eck-stack/charts/eck-logstash/examples/multi.yaml
+++ b/addons/eck-stack/charts/eck-logstash/examples/multi.yaml
@@ -1,0 +1,78 @@
+---
+# values corresponding to config/recipes/logstash/logstash-multi.yaml
+version: 9.1.0
+
+pipelines:
+  - pipeline.id: main
+    config.string: |
+      input {
+        beats {
+          port => 5044
+        }
+      }
+      filter {
+        grok {
+          match => { "message" => "%{HTTPD_COMMONLOG}"}
+        }
+        geoip {
+          source => "[source][address]"
+          target => "[source]"
+        }
+      }
+      output {
+        pipeline {
+          send_to => 'prod'
+        }
+        pipeline {
+          send_to => 'qa'
+        }
+      }
+  - pipeline.id: production
+    config.string: |
+      input {
+        pipeline {
+          address => 'prod'
+        }
+      }
+      output {
+        elasticsearch {
+          hosts => [ "${PROD_ES_ES_HOSTS}" ]
+          user => "${PROD_ES_ES_USER}"
+          password => "${PROD_ES_ES_PASSWORD}"
+          ssl_certificate_authorities => "${PROD_ES_ES_SSL_CERTIFICATE_AUTHORITY}"
+        }
+      }
+  - pipeline.id: qa
+    config.string: |
+      input {
+        pipeline {
+          address => 'qa'
+        }
+      }
+      output {
+        elasticsearch {
+          hosts => [ "${QA_ES_ES_HOSTS}" ]
+          user => "${QA_ES_ES_USER}"
+          password => "${QA_ES_ES_PASSWORD}"
+          ssl_certificate_authorities => "${QA_ES_ES_SSL_CERTIFICATE_AUTHORITY}"
+        }
+      }
+
+elasticsearchRefs:
+  - clusterName: prod-es
+    name: production
+  - clusterName: qa-es
+    name: qa
+    namespace: qa
+
+services:
+  - name: beats
+    service:
+      spec:
+        type: ClusterIP
+        ports:
+          - port: 5044
+            name: "filebeat"
+            protocol: TCP
+            targetPort: 5044
+

--- a/addons/eck-stack/charts/eck-logstash/examples/volumes.yaml
+++ b/addons/eck-stack/charts/eck-logstash/examples/volumes.yaml
@@ -1,0 +1,107 @@
+---
+# values corresponding to config/recipes/logstash/logstash-volumes.yaml
+version: 9.1.0
+
+config:
+  log.level: info
+  queue.type: persisted
+  path.queue: /usr/share/logstash/pq
+
+podTemplate:
+  spec:
+    containers:
+      - name: logstash
+        volumeMounts:
+          - mountPath: /usr/share/logstash/pq
+            name: pq
+            readOnly: false
+          - mountPath: /usr/share/logstash/dlq
+            name: dlq
+            readOnly: false
+
+pipelines:
+  - pipeline.id: dlq_read
+    dead_letter_queue.enable: false
+    config.string: |
+      input {
+        dead_letter_queue {
+          path => "/usr/share/logstash/dlq"
+          commit_offsets => true
+          pipeline_id => "beats"
+          clean_consumed => true
+        }
+      }
+      filter {
+        mutate {
+          remove_field => "[geoip][location]"
+        }
+      }
+      output {
+        elasticsearch {
+          hosts => [ "${ECK_ES_HOSTS}" ]
+          user => "${ECK_ES_USER}"
+          password => "${ECK_ES_PASSWORD}"
+          ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+        }
+      }
+  - pipeline.id: beats
+    dead_letter_queue.enable: true
+    path.dead_letter_queue: /usr/share/logstash/dlq
+    config.string: |
+      input {
+        beats {
+          port => 5044
+        }
+      }
+      filter {
+        grok {
+          match => { "message" => "%{HTTPD_COMMONLOG}"}
+        }
+        geoip {
+          source => "[source][address]"
+          target => "[source]"
+        }
+      }
+      output {
+        elasticsearch {
+          hosts => [ "${ECK_ES_HOSTS}" ]
+          user => "${ECK_ES_USER}"
+          password => "${ECK_ES_PASSWORD}"
+          ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+        }
+      }
+
+volumeClaimTemplates:
+  - metadata:
+      name: pq
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+  - metadata:
+      name: dlq
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+
+
+elasticsearchRefs:
+  - clusterName: eck
+    name: elasticsearch
+
+services:
+  - name: beats
+    service:
+      spec:
+        type: ClusterIP
+        ports:
+          - port: 5044
+            name: "filebeat"
+            protocol: TCP
+            targetPort: 5044
+

--- a/addons/eck-stack/charts/eck-logstash/templates/NOTES.txt
+++ b/addons/eck-stack/charts/eck-logstash/templates/NOTES.txt
@@ -1,0 +1,6 @@
+
+1. Check Logstash status
+  $ kubectl get logstash {{ include "logstash.fullname" . }} -n {{ .Release.Namespace }}
+
+2. Check Logstash pod status
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l logstash.k8s.elastic.co/name={{ include "logstash.fullname" . }}

--- a/addons/eck-stack/charts/eck-logstash/templates/_helpers.tpl
+++ b/addons/eck-stack/charts/eck-logstash/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "logstash.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "logstash.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "logstash.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "logstash.labels" -}}
+helm.sh/chart: {{ include "logstash.chart" . }}
+{{ include "logstash.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "logstash.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "logstash.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/addons/eck-stack/charts/eck-logstash/templates/logstash.yaml
+++ b/addons/eck-stack/charts/eck-logstash/templates/logstash.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: logstash.k8s.elastic.co/v1alpha1
+kind: Logstash
+metadata:
+  name: {{ include "logstash.fullname" . }}
+  labels:
+    {{- include "logstash.labels" . | nindent 4 }}
+  annotations:
+    eck.k8s.elastic.co/license: basic
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  version: {{ required "A Logstash version is required" .Values.version }}
+  count: {{ required "A pod count is required" .Values.count }}
+  {{- with .Values.image }}
+  image: {{ . }}
+  {{- end }}
+  {{- with .Values.serviceAccountName }}
+  serviceAccountName: {{ . }}
+  {{- end }}
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
+
+  {{- if and .Values.config .Values.configRef }}
+  {{- fail "config and configRef are mutually exclusive!" }}
+  {{- end }}
+  {{- with .Values.config }}
+  config:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.configRef }}
+  configRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.podTemplate }}
+  podTemplate:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.monitoring }}
+  monitoring:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.pipelines .Values.pipelinesRef }}
+  {{- fail "pipelines and pipelinesRef are mutually exclusive!" }}
+  {{- end }}
+  {{- with .Values.pipelinesRef }}
+  pipelinesRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.pipelines  }}
+  pipelines: {{ toYaml .Values.pipelines | nindent 4 }}
+  {{- end }}
+  volumeClaimTemplates: {{ toYaml .Values.volumeClaimTemplates | nindent 4 }}
+  elasticsearchRefs: {{ toYaml .Values.elasticsearchRefs | nindent 4 }}
+  services: {{ toYaml .Values.services | nindent 4 }}
+  secureSettings: {{ toYaml .Values.secureSettings | nindent 4 }}

--- a/addons/eck-stack/charts/eck-logstash/values.yaml
+++ b/addons/eck-stack/charts/eck-logstash/values.yaml
@@ -1,0 +1,115 @@
+---
+# Default values for eck-logstash.
+# This is a YAML-formatted file.
+
+# Overridable names of the Logstash resource.
+# By default, this is the Release name set for the chart,
+# followed by 'eck-logstash'.
+#
+# nameOverride will override the name of the Chart with the name set here,
+# so nameOverride: quickstart, would convert to '{{ Release.name }}-quickstart'
+#
+# nameOverride: "quickstart"
+#
+# fullnameOverride will override both the release name, and the chart name,
+# and will name the Logstash resource exactly as specified.
+#
+# fullnameOverride: "quickstart"
+
+# Version of Logstash.
+#
+version: 9.1.0
+
+# Logstash Docker image to deploy
+#
+# image:
+
+# Used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
+# Can only be used if ECK is enforcing RBAC on references.
+#
+# serviceAccountName: ""
+
+# Labels that will be applied to Logstash.
+#
+labels: {}
+
+# Annotations that will be applied to Logstash.
+#
+annotations: {}
+
+# Number of revisions to retain to allow rollback in the underlying StatefulSets.
+# By default, if not set, Kubernetes sets 10.
+#
+# revisionHistoryLimit: 2
+
+# Controlling the number of pods.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-scaling-logstash.html
+#
+count: 1
+
+# The logstash configuration, the ECK equivalent to logstash.yml
+#
+# NOTE: The `config` and `configRef` fields are mutually exclusive. Only one of them should be defined at a time,
+# as using both may cause conflicts.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-configuring-logstash
+#
+config: {}
+
+# Reference a configuration in a Secret.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-configuring-logstash
+#
+# configRef:
+#   secretName: ''
+
+# Set podTemplate to customize the pod used by Logstash
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-customize-pods.html
+#
+podTemplate: {}
+
+# Settings for configuring stack monitoring.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-stack-monitoring.html
+#
+monitoring: {}
+  # metrics:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability 
+  # logs:
+  #   elasticsearchRefs:
+  #   - name: monitoring
+  #     namespace: observability
+
+# The Logstash pipelines, the ECK equivalent to pipelines.yml
+#
+# NOTE: The `pipelines` and `pipelinesRef` fields are mutually exclusive. Only one of them should be defined at a time,
+# as using both may cause conflicts.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-pipelines
+#
+pipelines: []
+
+# Reference a pipelines configuration in a Secret.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-pipelines
+#
+# pipelinesRef:
+#   secretName: ''
+
+# volumeClaimTemplates
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-volume-claim-settings
+#
+volumeClaimTemplates: []
+
+# ElasticsearchRefs are references to Elasticsearch clusters running in the same Kubernetes cluster.
+# Ensure that the 'clusterName' field matches what is referenced in the pipeline.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-pipelines-es
+#
+elasticsearchRefs: []
+#  - namespace: ''
+#    name: ''
+#    clusterName: ''
+#    serviceName: ''
+#    secretName: ''
+
+services: []
+
+# SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Logstash
+secureSettings: []

--- a/addons/eck-stack/examples/agent/fleet-agents.yaml
+++ b/addons/eck-stack/examples/agent/fleet-agents.yaml
@@ -1,0 +1,122 @@
+---
+eck-elasticsearch:
+  enabled: true
+
+  # Name of the Elasticsearch instance.
+  #
+  fullnameOverride: elasticsearch
+
+  nodeSets:
+  - name: default
+    count: 3
+    # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+    # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+    # and leave node.store.allow_mmap unset.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+    #
+    config:
+      node.store.allow_mmap: false
+
+eck-kibana:
+  enabled: true
+
+  # Name of the Kibana instance.
+  #
+  fullnameOverride: kibana
+  
+  # Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
+  #
+  elasticsearchRef:
+    name: elasticsearch
+
+  config:
+    # Note that these are specific to the namespace into which this example is installed, and are
+    # using `elastic-stack` as configured here and detailed in the README when installing:
+    #
+    # `helm install es-kb-quickstart elastic/eck-stack -n elastic-stack`
+    #
+    # If installed outside of the `elastic-stack` namespace, the following 2 lines need modification.
+    xpack.fleet.agents.elasticsearch.hosts: ["https://elasticsearch-es-http.elastic-stack.svc:9200"]
+    xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server-agent-http.elastic-stack.svc:8220"]
+    xpack.fleet.packages:
+    - name: system
+      version: latest
+    - name: elastic_agent
+      version: latest
+    - name: fleet_server
+      version: latest
+    - name: kubernetes
+      version: latest
+    xpack.fleet.agentPolicies:
+    - name: Fleet Server on ECK policy
+      id: eck-fleet-server
+      namespace: default
+      is_managed: true
+      monitoring_enabled:
+      - logs
+      - metrics
+      package_policies:
+      - name: fleet_server-1
+        id: fleet_server-1
+        package:
+          name: fleet_server
+    - name: Elastic Agent on ECK policy
+      id: eck-agent
+      namespace: default
+      is_managed: true
+      monitoring_enabled:
+      - logs
+      - metrics
+      unenroll_timeout: 900
+      package_policies:
+      - package:
+          name: system
+        name: system-1
+      - package:
+          name: kubernetes
+        name: kubernetes-1
+
+eck-agent:
+  enabled: true
+  
+  # Agent policy to be used.
+  policyID: eck-agent
+  # Reference to ECK-managed Kibana instance.
+  #
+  kibanaRef:
+    name: kibana
+  elasticsearchRefs: []
+  # Reference to ECK-managed Fleet instance.
+  #
+  fleetServerRef:
+    name: fleet-server
+  
+  mode: fleet
+  daemonSet:
+    podTemplate:
+      spec:
+        serviceAccountName: elastic-agent
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+        automountServiceAccountToken: true
+        securityContext:
+          runAsUser: 0
+  
+eck-fleet-server:
+  enabled: true
+
+  fullnameOverride: "fleet-server"
+
+  deployment:
+    replicas: 1
+    podTemplate:
+      spec:
+        serviceAccountName: fleet-server
+        automountServiceAccountToken: true
+
+  # Agent policy to be used.
+  policyID: eck-fleet-server
+  kibanaRef:
+    name: kibana
+  elasticsearchRefs:
+  - name: elasticsearch

--- a/addons/eck-stack/examples/apm-server/basic.yaml
+++ b/addons/eck-stack/examples/apm-server/basic.yaml
@@ -1,0 +1,52 @@
+---
+eck-elasticsearch:
+  enabled: true
+
+  # Name of the Elasticsearch instance.
+  #
+  fullnameOverride: elasticsearch
+
+  nodeSets:
+  - name: default
+    count: 3
+    # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+    # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+    # and leave node.store.allow_mmap unset.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+    #
+    config:
+      node.store.allow_mmap: false
+
+eck-kibana:
+  enabled: true
+
+  # Name of the Kibana instance.
+  #
+  fullnameOverride: kibana
+
+  spec:
+    config:
+      xpack.fleet.packages:
+      - name: apm
+        version: latest
+
+eck-apm-server:
+  enabled: true
+
+  # Count of APM Server replicas to create.
+  #
+  count: 1
+
+  # Reference to ECK-managed Elasticsearch resource.
+  #
+  elasticsearchRef:
+    name: elasticsearch
+  kibanaRef:
+    name: kibana
+  http:
+    service:
+      spec:
+        ports:
+        - name: http
+          port: 8200
+          targetPort: 8200

--- a/addons/eck-stack/examples/apm-server/jaeger-with-http-configuration.yaml
+++ b/addons/eck-stack/examples/apm-server/jaeger-with-http-configuration.yaml
@@ -1,0 +1,60 @@
+---
+eck-elasticsearch:
+  enabled: true
+
+  # Name of the Elasticsearch instance.
+  #
+  fullnameOverride: elasticsearch
+
+  nodeSets:
+  - name: default
+    count: 3
+    # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+    # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+    # and leave node.store.allow_mmap unset.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+    #
+    config:
+      node.store.allow_mmap: false
+
+eck-kibana:
+  enabled: true
+
+  # Name of the Kibana instance.
+  #
+  fullnameOverride: kibana
+
+  spec:
+    config:
+      xpack.fleet.packages:
+      - name: apm
+        version: latest
+
+eck-apm-server:
+  enabled: true
+
+  # Count of APM Server replicas to create.
+  #
+  count: 1
+
+  config:
+    name: elastic-apm
+    apm-server.jaeger.grpc.enabled: true
+    apm-server.jaeger.grpc.host: "0.0.0.0:14250"
+
+  # Reference to ECK-managed Elasticsearch resource.
+  #
+  elasticsearchRef:
+    name: elasticsearch
+  kibanaRef:
+    name: kibana
+  http:
+    service:
+      spec:
+        ports:
+        - name: http
+          port: 8200
+          targetPort: 8200
+        - name: grpc
+          port: 14250
+          targetPort: 14250

--- a/addons/eck-stack/examples/beats/metricbeat_hosts.yaml
+++ b/addons/eck-stack/examples/beats/metricbeat_hosts.yaml
@@ -1,0 +1,217 @@
+eck-elasticsearch:
+  enabled: true
+
+  # Name of the Elasticsearch resource.
+  #
+  fullnameOverride: quickstart
+
+  # Version of Elasticsearch.
+  #
+  version: 9.1.0
+
+  nodeSets:
+  - name: default
+    count: 3
+    config:
+      # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+      # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+      # and leave node.store.allow_mmap unset.
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+      #
+      node.store.allow_mmap: false
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Gi
+        # Adjust to your storage class name
+        #
+        # storageClassName: local-storage
+
+eck-kibana:
+  enabled: true
+
+  # Name of the Kibana resource.
+  #
+  fullnameOverride: quickstart
+  
+  # Version of Kibana.
+  #
+  version: 9.1.0
+  
+  spec:
+    # Count of Kibana replicas to create.
+    #
+    count: 1
+  
+    # Reference to ECK-managed Elasticsearch resource, ideally from {{ "elasticsearch.fullname" }}
+    #
+    elasticsearchRef:
+      name: quickstart
+
+eck-beats:
+  enabled: true
+  name: metricbeat
+  type: metricbeat
+  version: 9.1.0
+  elasticsearchRef:
+    name: quickstart
+  kibanaRef:
+    name: quickstart
+  config:
+    # Since filebeat is used in the default values, this needs to be removed with an empty list. 
+    filebeat.inputs: []
+    metricbeat:
+      autodiscover:
+        providers:
+        - hints:
+            default_config: {}
+            enabled: "true"
+          node: ${NODE_NAME}
+          type: kubernetes
+      modules:
+      - module: system
+        period: 10s
+        metricsets:
+        - cpu
+        - load
+        - memory
+        - network
+        - process
+        - process_summary
+        process:
+          include_top_n:
+            by_cpu: 5
+            by_memory: 5
+        processes:
+        - .*
+      - module: system
+        period: 1m
+        metricsets:
+        - filesystem
+        - fsstat
+        processors:
+        - drop_event:
+            when:
+              regexp:
+                system:
+                  filesystem:
+                    mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib)($|/)
+      - module: kubernetes
+        period: 10s
+        node: ${NODE_NAME}
+        hosts:
+        - https://${NODE_NAME}:10250
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        ssl:
+          verification_mode: none
+        metricsets:
+        - node
+        - system
+        - pod
+        - container
+        - volume
+    processors:
+    - add_cloud_metadata: {}
+    - add_host_metadata: {}
+  daemonSet:
+    podTemplate:
+      spec:
+        serviceAccountName: metricbeat
+        automountServiceAccountToken: true # some older Beat versions are depending on this settings presence in k8s context
+        containers:
+        - args:
+          - -e
+          - -c
+          - /etc/beat.yml
+          - --system.hostfs=/hostfs
+          name: metricbeat
+          volumeMounts:
+          - mountPath: /hostfs/sys/fs/cgroup
+            name: cgroup
+          - mountPath: /var/run/docker.sock
+            name: dockersock
+          - mountPath: /hostfs/proc
+            name: proc
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        dnsPolicy: ClusterFirstWithHostNet
+        hostNetwork: true # Allows to provide richer host metadata
+        securityContext:
+          runAsUser: 0
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: cgroup
+        - hostPath:
+            path: /var/run/docker.sock
+          name: dockersock
+        - hostPath:
+            path: /proc
+          name: proc
+  
+  clusterRole:
+    # permissions needed for metricbeat
+    # source: https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-kubernetes.html
+    name: metricbeat
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - "extensions"
+      resources:
+      - replicasets
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - apps
+      resources:
+      - statefulsets
+      - deployments
+      - replicasets
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/stats
+      verbs:
+      - get
+    - nonResourceURLs:
+      - /metrics
+      verbs:
+      - get
+  
+  serviceAccount:
+    name: metricbeat
+  
+  clusterRoleBinding:
+    name: metricbeat
+    subjects:
+    - kind: ServiceAccount
+      name: metricbeat
+    roleRef:
+      kind: ClusterRole
+      name: metricbeat
+      apiGroup: rbac.authorization.k8s.io

--- a/addons/eck-stack/examples/custom-elasticsearch-kibana.yaml
+++ b/addons/eck-stack/examples/custom-elasticsearch-kibana.yaml
@@ -1,0 +1,78 @@
+---
+eck-elasticsearch:
+  # Name of the Elasticsearch resource.
+  #
+  fullnameOverride: quickstart
+
+  # Version of Elasticsearch.
+  #
+  version: 9.1.0
+
+  nodeSets:
+  - name: default
+    count: 1
+    config:
+      # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+      # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+      # and leave node.store.allow_mmap unset.
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+      #
+      node.store.allow_mmap: false
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Gi
+        # Adjust to your storage class name
+        #
+        # storageClassName: local-storage
+
+eck-kibana:
+  # Name of the Kibana resource.
+  #
+  fullnameOverride: quickstart
+  
+  # Version of Kibana.
+  #
+  version: 9.1.0
+  
+  spec:
+    # Count of Kibana replicas to create.
+    #
+    count: 1
+  
+    # Reference to ECK-managed Elasticsearch resource, ideally from {{ "elasticsearch.fullname" }}
+    #
+    elasticsearchRef:
+      name: quickstart
+      # namespace: default
+    http:
+      service:
+        spec:
+          # Type of service to deploy for Kibana.
+          # This deploys a load balancer in a cloud service provider, where supported.
+          # 
+          type: LoadBalancer
+      # tls:
+      #   selfSignedCertificate:
+      #     subjectAltNames:
+      #     - ip: 1.2.3.4
+      #     - dns: kibana.example.com
+    podTemplate:
+      spec:
+        containers:
+        - name: kibana
+          env:
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=2048"
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 0.5
+            limits:
+              memory: 2.5Gi
+              cpu: 2

--- a/addons/eck-stack/examples/elasticsearch/hot-warm-cold.yaml
+++ b/addons/eck-stack/examples/elasticsearch/hot-warm-cold.yaml
@@ -1,0 +1,199 @@
+---
+eck-elasticsearch:
+  nodeSets:
+  - name: masters
+    count: 1
+    config:
+      node.roles: ["master"]
+      # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+      # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+      # and leave node.store.allow_mmap unset.
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+      #
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 8Gi
+              cpu: 2
+        # Affinity/Anti-affinity settings for controlling the 'spreading' of Elasticsearch
+        # pods across existing hosts.
+        # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+        # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-affinity-options
+        #
+        # affinity:
+        #   nodeAffinity:
+        #     requiredDuringSchedulingIgnoredDuringExecution:
+        #       nodeSelectorTerms:
+        #       - matchExpressions:
+        #         - key: beta.kubernetes.io/instance-type
+        #           operator: In
+        #           # This should be adjusted to the instance type according to your setup
+        #           #
+        #           values:
+        #           - highio
+    # Volume Claim settings.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
+    #
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Ti
+        # Adjust to your storage class name
+        #
+        # storageClassName: local-storage
+  - name: hot
+    count: 1
+    config:
+      node.roles: ["data_hot", "data_content", "ingest"]
+      # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+      # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+      # and leave node.store.allow_mmap unset.
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+      #
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 16Gi
+              cpu: 4
+        # Affinity/Anti-affinity settings for controlling the 'spreading' of Elasticsearch
+        # pods across existing hosts.
+        # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+        # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-affinity-options
+        #
+        # affinity:
+        #   nodeAffinity:
+        #     requiredDuringSchedulingIgnoredDuringExecution:
+        #       nodeSelectorTerms:
+        #       - matchExpressions:
+        #         - key: beta.kubernetes.io/instance-type
+        #           operator: In
+        #           # This should be adjusted to the instance type according to your setup
+        #           #
+        #           values:
+        #           - highio
+    # Volume Claim settings.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
+    #
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Ti
+        # Adjust to your storage class name
+        #
+        # storageClassName: local-storage
+  - name: warm
+    count: 1
+    config:
+      node.roles: ["data_warm"]
+      # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+      # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+      # and leave node.store.allow_mmap unset.
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+      #
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 16Gi
+              cpu: 2
+        # Affinity/Anti-affinity settings for controlling the 'spreading' of Elasticsearch
+        # pods across existing hosts.
+        # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+        # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-affinity-options
+        #
+        # affinity:
+        #   nodeAffinity:
+        #     requiredDuringSchedulingIgnoredDuringExecution:
+        #       nodeSelectorTerms:
+        #       - matchExpressions:
+        #         - key: beta.kubernetes.io/instance-type
+        #           operator: In
+        #           # This should be adjusted to the instance type according to your setup
+        #           #
+        #           values:
+        #           - highstorage
+    # Volume Claim settings.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
+    #
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Ti
+        # Adjust to your storage class name
+        #
+        # storageClassName: local-storage
+  - name: cold
+    count: 1
+    config:
+      node.roles: ["data_cold"]
+      # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+      # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+      # and leave node.store.allow_mmap unset.
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+      #
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 8Gi
+              cpu: 2
+        # Affinity/Anti-affinity settings for controlling the 'spreading' of Elasticsearch
+        # pods across existing hosts.
+        # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+        # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-node-scheduling.html#k8s-affinity-options
+        #
+        # affinity:
+        #   nodeAffinity:
+        #     requiredDuringSchedulingIgnoredDuringExecution:
+        #       nodeSelectorTerms:
+        #       - matchExpressions:
+        #         - key: beta.kubernetes.io/instance-type
+        #           operator: In
+        #           # This should be adjusted to the instance type according to your setup
+        #           #
+        #           values:
+        #           - highstorage
+    # Volume Claim settings.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-volume-claim-templates.html
+    #
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Ti
+        # Adjust to your storage class name
+        #
+        # storageClassName: local-storage

--- a/addons/eck-stack/examples/elasticsearch/ingress/elasticsearch-ingress-gke.yaml
+++ b/addons/eck-stack/examples/elasticsearch/ingress/elasticsearch-ingress-gke.yaml
@@ -1,0 +1,40 @@
+# The following is an example of an Elasticsearch resource that is configured to use an Ingress resource in a GKE cluster.
+# Additional examples of exposing Elasticsearch with Ingress resources can be found in the following location:
+# https://github.com/elastic/cloud-on-k8s/tree/main/deploy/eck-stack/charts/eck-elasticsearch/examples/ingress
+#
+eck-elasticsearch:
+  enabled: true
+
+  ingress:
+    enabled: true
+    annotations:
+      my: annotation
+    labels:
+      my: label
+    pathType: Prefix
+    hosts:
+    - host: "elasticsearch.company.dev"
+      path: "/"
+  http:
+    service:
+      metadata:
+        annotations:
+          # This is required for `ClusterIP` services (which are the default ECK service type) to be used with Ingress in GKE clusters.
+          cloud.google.com/neg: '{"ingress": true}'
+          # This is required to enable the GKE Ingress Controller to use HTTPS as the backend protocol.
+          cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+  nodeSets:
+  - name: default
+    count: 3
+    # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+    # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+    # and leave node.store.allow_mmap unset.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+    #
+    config:
+      node.store.allow_mmap: false
+      # Enable anonymous access to allow GCLB health probes to succeed
+      xpack.security.authc:
+        anonymous:
+          username: anon
+          roles: monitoring_user

--- a/addons/eck-stack/examples/enterprise-search/basic.yaml
+++ b/addons/eck-stack/examples/enterprise-search/basic.yaml
@@ -1,0 +1,42 @@
+---
+eck-elasticsearch:
+  enabled: true
+
+  # Name of the Elasticsearch instance.
+  #
+  fullnameOverride: elasticsearch
+
+  nodeSets:
+  - name: default
+    count: 3
+    # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+    # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+    # and leave node.store.allow_mmap unset.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+    #
+    config:
+      node.store.allow_mmap: false
+
+eck-kibana:
+  enabled: true
+
+  # Name of the Kibana instance.
+  #
+  fullnameOverride: kibana
+
+  elasticsearchRef:
+    name: elasticsearch
+
+  spec:
+    enterpriseSearchRef:
+      name: enterprise-search
+
+eck-enterprise-search:
+  enabled: true
+
+  # Name of the Enterprise Search instance.
+  #
+  fullnameOverride: enterprise-search
+
+  elasticsearchRef:
+    name: elasticsearch

--- a/addons/eck-stack/examples/enterprise-search/with-custom-configuration.yaml
+++ b/addons/eck-stack/examples/enterprise-search/with-custom-configuration.yaml
@@ -1,0 +1,52 @@
+---
+eck-elasticsearch:
+  enabled: true
+
+  # Name of the Elasticsearch instance.
+  #
+  fullnameOverride: elasticsearch
+
+  nodeSets:
+  - name: default
+    count: 3
+    # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+    # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+    # and leave node.store.allow_mmap unset.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+    #
+    config:
+      node.store.allow_mmap: false
+
+eck-kibana:
+  enabled: true
+
+  # Name of the Kibana instance.
+  #
+  fullnameOverride: kibana
+
+  elasticsearchRef:
+    name: elasticsearch
+
+  spec:
+    enterpriseSearchRef:
+      name: enterprise-search
+
+eck-enterprise-search:
+  enabled: true
+
+  # Name of the Enterprise Search instance.
+  #
+  fullnameOverride: enterprise-search
+
+  config:
+    # configure app search document size limit
+    app_search.engine.document_size.limit: 100kb
+
+  http:
+    service:
+      metadata:
+        labels:
+          my-custom: label
+
+  elasticsearchRef:
+    name: elasticsearch

--- a/addons/eck-stack/examples/kibana/http-configuration.yaml
+++ b/addons/eck-stack/examples/kibana/http-configuration.yaml
@@ -1,0 +1,23 @@
+---
+eck-kibana:
+  # Count of Kibana replicas to create.
+  #
+  count: 1
+
+  # Reference to ECK-managed Elasticsearch resource, ideally from {{ "elasticsearch.fullname" }}
+  #
+  elasticsearchRef:
+    name: es-quickstart-eck-elasticsearch
+    # namespace: default
+  http:
+    service:
+      spec:
+        # Type of service to deploy for Kibana.
+        # This deploys a load balancer in a cloud service provider, where supported.
+        # 
+        type: LoadBalancer
+    # tls:
+    #   selfSignedCertificate:
+    #     subjectAltNames:
+    #     - ip: 1.2.3.4
+    #     - dns: kibana.example.com

--- a/addons/eck-stack/examples/kibana/ingress/kibana-gke.yaml
+++ b/addons/eck-stack/examples/kibana/ingress/kibana-gke.yaml
@@ -1,0 +1,80 @@
+# The following is an example of a Kibana resource that is configured to use an Ingress resource in a GKE cluster.
+# Additional examples of exposing Kibana with Ingress resources can be found in the following location:
+# https://github.com/elastic/cloud-on-k8s/tree/main/deploy/eck-stack/charts/eck-kibana/examples/ingress
+#
+eck-elasticsearch:
+  enabled: true
+
+  # Name of the Elasticsearch instance.
+  #
+  fullnameOverride: elasticsearch  
+
+  ingress:
+    enabled: true
+    annotations:
+      my: annotation
+    labels:
+      my: label
+    pathType: Prefix
+    hosts:
+    - host: "elasticsearch.company.dev"
+      path: "/"
+    tls:
+      enabled: true
+
+  http:
+    service:
+      metadata:
+        annotations:
+          # This is required for `ClusterIP` services (which are the default ECK service type) to be used with Ingress in GKE clusters.
+          cloud.google.com/neg: '{"ingress": true}'
+          cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+
+  nodeSets:
+  - name: default
+    count: 3
+    # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+    # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+    # and leave node.store.allow_mmap unset.
+    # ref: https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+    #
+    config:
+      node.store.allow_mmap: false
+      # Enable anonymous access to allow GCLB health probes to succeed
+      xpack.security.authc:
+        anonymous:
+          username: anon
+          roles: monitoring_user
+
+eck-kibana:
+  enabled: true
+
+  # Name of the Kibana instance.
+  #
+  fullnameOverride: kibana
+  
+  # Reference to ECK-managed Elasticsearch instance, ideally from {{ "elasticsearch.fullname" }}
+  #
+  elasticsearchRef:
+    name: elasticsearch
+
+  config:
+    server:
+      publicBaseUrl: "https://kibana.company.dev"
+
+  http:
+    service:
+      metadata:
+        annotations:
+          # This is required for `ClusterIP` services (which are the default ECK service type) to be used with Ingress in GKE clusters.
+          cloud.google.com/neg: '{"ingress": true}'
+          cloud.google.com/app-protocols: '{"https":"HTTPS"}'
+
+  ingress:
+    enabled: true
+    pathType: Prefix
+    hosts:
+    - host: "kibana.company.dev"
+      path: "/"
+    tls:
+      enabled: true

--- a/addons/eck-stack/examples/logstash/basic-eck.yaml
+++ b/addons/eck-stack/examples/logstash/basic-eck.yaml
@@ -1,0 +1,112 @@
+---
+eck-elasticsearch:
+  nodeSets:
+  - name: default
+    count: 3
+    config:
+      # Comment out when setting the vm.max_map_count via initContainer, as these are mutually exclusive.
+      # For production workloads, it is strongly recommended to increase the kernel setting vm.max_map_count to 262144
+      # and leave node.store.allow_mmap unset.
+      # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-virtual-memory.html
+      #
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        containers:
+        - name: elasticsearch
+          resources:
+            limits:
+              memory: 2Gi
+            requests:
+              memory: 2Gi
+eck-kibana:
+  enabled: true
+  spec:
+    count: 1
+    elasticsearchRef:
+      name: elasticsearch
+eck-beats:
+  enabled: true
+  deployment:
+    podTemplate:
+      spec:
+        automountServiceAccountToken: true
+        initContainers:
+          - name: download-tutorial
+            image: curlimages/curl
+            command: ["/bin/sh"]
+            args: ["-c", "curl -L https://download.elastic.co/demos/logstash/gettingstarted/logstash-tutorial.log.gz | gunzip -c > /data/logstash-tutorial.log"]
+            volumeMounts:
+              - name: data
+                mountPath: /data
+        containers:
+          - name: filebeat
+            securityContext:
+              runAsUser: 1000
+            volumeMounts:
+              - name: data
+                mountPath: /data
+              - name: beat-data
+                mountPath: /usr/share/filebeat/data
+        volumes:
+          - name: data
+            emptydir: {}
+          - name: beat-data
+            emptydir: {}
+  type: filebeat
+  config:
+    filebeat.inputs:
+    - type: log
+      paths:
+        - /data/logstash-tutorial.log
+    processors:
+    - add_host_metadata: {}
+    - add_cloud_metadata: {}
+    output.logstash:
+      # This needs to be {{logstash-name}}-ls-beats:5044
+      hosts: ["logstash-ls-beats-ls-beats:5044"]
+eck-logstash:
+  enabled: true
+  # This is required to be able to set the logstash
+  # output of beats in a consistent manner.
+  fullnameOverride: "logstash-ls-beats"
+  elasticsearchRefs:
+    # This clusterName is required to match the environment variables
+    # used in the below config.string output section.
+    - clusterName: eck
+      name: elasticsearch
+  pipelines:
+    - pipeline.id: main
+      config.string: |
+        input {
+          beats {
+            port => 5044
+          }
+        }
+        filter {
+          grok {
+            match => { "message" => "%{HTTPD_COMMONLOG}"}
+          }
+          geoip {
+            source => "[source][address]"
+            target => "[source]"
+          }
+        }
+        output {
+          elasticsearch {
+            hosts => [ "${ECK_ES_HOSTS}" ]
+            user => "${ECK_ES_USER}"
+            password => "${ECK_ES_PASSWORD}"
+            ssl_certificate_authorities => "${ECK_ES_SSL_CERTIFICATE_AUTHORITY}"
+          }
+        }
+  services:
+    - name: beats
+      service:
+        spec:
+          type: ClusterIP
+          ports:
+            - port: 5044
+              name: "filebeat"
+              protocol: TCP
+              targetPort: 5044

--- a/addons/eck-stack/form.yaml
+++ b/addons/eck-stack/form.yaml
@@ -1,0 +1,37 @@
+name: ECK Elasticsearch
+tabs:
+- name: main
+  label: Main Settings
+  sections:
+  - name: nodes
+    contents:
+    - type: heading
+      label: Node Settings
+    - type: subtitle
+      label: Configure the size of elasticsearch cluster. By default, Porter runs a single node elasticsearch cluster.
+    - type: number-input
+      label: Number of nodes
+      variable: replicas
+      settings:
+        default: 1
+- name: resources
+  label: Computing resources
+  sections:
+  - name: main_section
+    contents:
+    - type: heading
+      label: Resources
+    - type: subtitle
+      label: Configure resources assigned to this container.
+    - type: number-input
+      label: RAM
+      variable: resources.requests.memory
+      settings:
+        unit: Mi
+        default: 512
+    - type: number-input
+      label: CPU
+      variable: resources.requests.cpu
+      settings:
+        unit: m
+        default: 500

--- a/addons/eck-stack/templates/NOTES.txt
+++ b/addons/eck-stack/templates/NOTES.txt
@@ -1,0 +1,10 @@
+Elasticsearch ECK-Stack {{ .Chart.Version }} has been deployed successfully!
+
+To see status of all resources, run
+
+kubectl get elastic -n {{ .Release.Namespace }} -l "app.kubernetes.io/instance"={{ .Release.Name }}
+
+More information on the Elastic ECK Operator, and its Helm chart can be found
+within our documentation.
+
+https://www.elastic.co/guide/en/cloud-on-k8s/current/index.html

--- a/addons/eck-stack/templates/_helpers.tpl
+++ b/addons/eck-stack/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "eck-stack.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "eck-stack.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "eck-stack.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "eck-stack.labels" -}}
+helm.sh/chart: {{ include "eck-stack.chart" . }}
+{{ include "eck-stack.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "eck-stack.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "eck-stack.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/addons/eck-stack/values.yaml
+++ b/addons/eck-stack/values.yaml
@@ -13,7 +13,7 @@ eck-elasticsearch:
 # If enabled, will use the eck-kibana chart and deploy a Kibana resource.
 #
 eck-kibana:
-  enabled: true
+  enabled: false
   # This is also adjusting the kibana reference to the elasticsearch resource named previously so that
   # both the eck-elasticsearch and the eck-kibana chart work together by default in the eck-stack chart.
   elasticsearchRef:

--- a/addons/eck-stack/values.yaml
+++ b/addons/eck-stack/values.yaml
@@ -1,0 +1,50 @@
+---
+# Default values for eck-stack.
+# This is a YAML-formatted file.
+
+# If enabled, will use the eck-elasticsearch chart and deploy an Elasticsearch resource.
+#
+eck-elasticsearch:
+  enabled: true
+  # This is adjusting the full name of the elasticsearch resource so that both the eck-elasticsearch
+  # and the eck-kibana chart work together by default in the eck-stack chart.
+  fullnameOverride: elasticsearch
+
+# If enabled, will use the eck-kibana chart and deploy a Kibana resource.
+#
+eck-kibana:
+  enabled: true
+  # This is also adjusting the kibana reference to the elasticsearch resource named previously so that
+  # both the eck-elasticsearch and the eck-kibana chart work together by default in the eck-stack chart.
+  elasticsearchRef:
+    name: elasticsearch
+
+# If enabled, will use the eck-agent chart and deploy an Elastic Agent instance.
+#
+eck-agent:
+  enabled: false
+
+# If enabled, will use the eck-fleet-server chart and deploy a Fleet Server resource.
+#
+eck-fleet-server:
+  enabled: false
+
+# If enabled, will use the eck-beats chart and deploy a Beats resource.
+#
+eck-beats:
+  enabled: false
+
+# If enabled, will use the eck-logstash chart and deploy a Logstash resource.
+#
+eck-logstash:
+  enabled: false
+
+# If enabled, will use the eck-apm-server chart and deploy a standalone APM Server resource.
+#
+eck-apm-server:
+  enabled: false
+
+# If enabled, will use the eck-enterprise-search chart and deploy a Enterprise Search resource.
+#
+eck-enterprise-search:
+  enabled: false


### PR DESCRIPTION
This PR adds Elastic's official ECK chart as an addon, with a view to replace the older `elasticsearch` Helm chart.