### PR TITLE
feat: add a host volumes options to porter apps

### DIFF
--- a/applications/job/templates/_helpers.tpl
+++ b/applications/job/templates/_helpers.tpl
@@ -109,7 +109,7 @@ Return true if volumeMounts should be rendered in the main container
 
 */}}
 {{- define "job.shouldRenderVolumeMounts" -}}
-{{- if or .Values.pvc.enabled .Values.multiplePvc.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) (and .Values.hostVolumeMounts (gt (len .Values.hostVolumeMounts) 0)) -}}
+{{- if or .Values.pvc.enabled .Values.multiplePvc.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) .Values.hostVolumeMounts -}}
 true
 {{- else -}}
 false

--- a/applications/job/templates/_helpers.tpl
+++ b/applications/job/templates/_helpers.tpl
@@ -109,7 +109,7 @@ Return true if volumeMounts should be rendered in the main container
 
 */}}
 {{- define "job.shouldRenderVolumeMounts" -}}
-{{- if or .Values.pvc.enabled .Values.multiplePvc.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) -}}
+{{- if or .Values.pvc.enabled .Values.multiplePvc.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) (and .Values.hostVolumeMounts (gt (len .Values.hostVolumeMounts) 0)) -}}
 true
 {{- else -}}
 false

--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -182,7 +182,6 @@ spec:
                   mountPath: {{ .Values.pvc.mountPath }}
               {{ end }}
               {{ if .Values.hostVolumeMounts }}
-              volumeMounts:
               {{ range .Values.hostVolumeMounts }}
                 - name: {{ .name }}
                   mountPath: {{ .mountPath }}
@@ -190,10 +189,10 @@ spec:
               {{ end }}
               {{- if .Values.multiplePvc.enabled }}
               {{- range .Values.multiplePvc.volumes }}
-              - name: {{ .name }}
-                mountPath: {{ .mountPath }}
-              {{- end }}
-              {{- end }}
+                - name: {{ .name }}
+                  mountPath: {{ .mountPath }}
+              {{ end }}
+              {{ end }}
               resources:
                 requests:
                   cpu: {{ .Values.resources.requests.cpu }}

--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -181,6 +181,13 @@ spec:
                 - name: "{{ include "docker-template.fullname" . }}-storage"
                   mountPath: {{ .Values.pvc.mountPath }}
               {{ end }}
+              {{ if .Values.hostVolumeMounts.enabled }}
+              volumeMounts:
+              {{ range .Values.hostVolumeMounts.volumes }}
+                - name: {{ .name }}
+                  mountPath: {{ .mountPath }}
+              {{ end }}
+              {{ end }}
               {{- if .Values.multiplePvc.enabled }}
               {{- range .Values.multiplePvc.volumes }}
               - name: {{ .name }}
@@ -257,7 +264,7 @@ spec:
                   mountPath: /secrets/
                   readOnly: true
           {{ end }}
-          {{ if or .Values.cloudsql.enabled .Values.fileSecretMounts.enabled .Values.pvc.enabled .Values.multiplePvc.enabled }}
+          {{ if or .Values.cloudsql.enabled .Values.fileSecretMounts.enabled .Values.pvc.enabled .Values.multiplePvc.enabled .Values.hostVolumeMounts.enabled }}
           volumes:
             {{ if .Values.cloudsql.enabled }}
             - name: "cloud-sql-proxy-service-account-secret"
@@ -285,6 +292,14 @@ spec:
             - name: {{ .mountPath }}
               secret:
                 secretName: "{{ .secretName }}"
+            {{ end }}
+            {{ end }}
+            {{ if .Values.hostVolumeMounts.enabled }}
+            {{ range .Values.hostVolumeMounts.volumes }}
+            - name: {{ .name }}
+              hostPath:
+                path: {{ .hostPath }}
+                type: {{ .type | default "DirectoryOrCreate" }}
             {{ end }}
             {{ end }}
           {{ end }}

--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -181,9 +181,9 @@ spec:
                 - name: "{{ include "docker-template.fullname" . }}-storage"
                   mountPath: {{ .Values.pvc.mountPath }}
               {{ end }}
-              {{ if .Values.hostVolumeMounts.enabled }}
+              {{ if .Values.hostVolumeMounts }}
               volumeMounts:
-              {{ range .Values.hostVolumeMounts.volumes }}
+              {{ range .Values.hostVolumeMounts }}
                 - name: {{ .name }}
                   mountPath: {{ .mountPath }}
               {{ end }}
@@ -264,7 +264,7 @@ spec:
                   mountPath: /secrets/
                   readOnly: true
           {{ end }}
-          {{ if or .Values.cloudsql.enabled .Values.fileSecretMounts.enabled .Values.pvc.enabled .Values.multiplePvc.enabled .Values.hostVolumeMounts.enabled }}
+          {{ if or .Values.cloudsql.enabled .Values.fileSecretMounts.enabled .Values.pvc.enabled .Values.multiplePvc.enabled .Values.hostVolumeMounts }}
           volumes:
             {{ if .Values.cloudsql.enabled }}
             - name: "cloud-sql-proxy-service-account-secret"
@@ -294,13 +294,11 @@ spec:
                 secretName: "{{ .secretName }}"
             {{ end }}
             {{ end }}
-            {{ if .Values.hostVolumeMounts.enabled }}
-            {{ range .Values.hostVolumeMounts.volumes }}
+            {{ range .Values.hostVolumeMounts }}
             - name: {{ .name }}
               hostPath:
                 path: {{ .hostPath }}
                 type: {{ .type | default "DirectoryOrCreate" }}
-            {{ end }}
             {{ end }}
           {{ end }}
           restartPolicy: Never

--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -100,6 +100,22 @@ fileSecretMounts:
   enabled: false
   mounts: []
 
+# Host volume mounts for mounting host directories into containers
+# Format: hostVolumeMounts: [{name: <NAME>, hostPath: <HOST_PATH>, mountPath: <CONTAINER_PATH>, type: <HOSTPATH_TYPE>},..]
+hostVolumeMounts:
+  enabled: false
+  volumes: []
+  # Example:
+  # volumes:
+  #   - name: nvme-storage
+  #     hostPath: /mnt/nvme-shared
+  #     mountPath: /tmp/nvme
+  #     type: DirectoryOrCreate
+  #   - name: docker-socket
+  #     hostPath: /var/run/docker.sock
+  #     mountPath: /var/run/docker.sock
+  #     type: Socket
+
 # hostIPC is required on pods that need to access the host's IPC namespace
 # this is the case for instance for pods that need to use the MPS sliced GPUs
 # enable this conservatively

--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -102,19 +102,17 @@ fileSecretMounts:
 
 # Host volume mounts for mounting host directories into containers
 # Format: hostVolumeMounts: [{name: <NAME>, hostPath: <HOST_PATH>, mountPath: <CONTAINER_PATH>, type: <HOSTPATH_TYPE>},..]
-hostVolumeMounts:
-  enabled: false
-  volumes: []
-  # Example:
-  # volumes:
-  #   - name: nvme-storage
-  #     hostPath: /mnt/nvme-shared
-  #     mountPath: /tmp/nvme
-  #     type: DirectoryOrCreate
-  #   - name: docker-socket
-  #     hostPath: /var/run/docker.sock
-  #     mountPath: /var/run/docker.sock
-  #     type: Socket
+hostVolumeMounts: []
+# Example:
+# hostVolumeMounts:
+#   - name: nvme-storage
+#     hostPath: /mnt/nvme-shared
+#     mountPath: /tmp/nvme
+#     type: DirectoryOrCreate
+#   - name: docker-socket
+#     hostPath: /var/run/docker.sock
+#     mountPath: /var/run/docker.sock
+#     type: Socket
 
 # hostIPC is required on pods that need to access the host's IPC namespace
 # this is the case for instance for pods that need to use the MPS sliced GPUs

--- a/applications/web/templates/_helpers.tpl
+++ b/applications/web/templates/_helpers.tpl
@@ -180,7 +180,7 @@ Return true if volumeMounts should be rendered in the main container
 
 */}}
 {{- define "web.shouldRenderVolumeMounts" -}}
-{{- if or .Values.datadogSocketVolume.enabled .Values.resources.requests.nvidiaGpu .Values.awsEfsStorage .Values.pvc.enabled .Values.multiplePvc.enabled .Values.emptyDir.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) -}}
+{{- if or .Values.datadogSocketVolume.enabled .Values.resources.requests.nvidiaGpu .Values.awsEfsStorage .Values.pvc.enabled .Values.multiplePvc.enabled .Values.emptyDir.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) .Values.hostVolumeMounts.enabled -}}
 true
 {{- else -}}
 false

--- a/applications/web/templates/_helpers.tpl
+++ b/applications/web/templates/_helpers.tpl
@@ -180,7 +180,7 @@ Return true if volumeMounts should be rendered in the main container
 
 */}}
 {{- define "web.shouldRenderVolumeMounts" -}}
-{{- if or .Values.datadogSocketVolume.enabled .Values.resources.requests.nvidiaGpu .Values.awsEfsStorage .Values.pvc.enabled .Values.multiplePvc.enabled .Values.emptyDir.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) .Values.hostVolumeMounts.enabled -}}
+{{- if or .Values.datadogSocketVolume.enabled .Values.resources.requests.nvidiaGpu .Values.awsEfsStorage .Values.pvc.enabled .Values.multiplePvc.enabled .Values.emptyDir.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) .Values.hostVolumeMounts -}}
 true
 {{- else -}}
 false

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -591,7 +591,7 @@ spec:
             secretName: "{{ .secretName }}"
         {{ end }}
         {{ end }}
-        {{- range .Values.hostVolumeMounts }}
+        {{ range .Values.hostVolumeMounts }}
         - name: {{ .name }}
           hostPath:
             path: {{ .hostPath }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -82,12 +82,14 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
+                  {{- if .Values.nodeGroups }}
                   - key: porter.run/node-group-id
                     operator: In
                     values:
                         {{- range $nodeGroup := .Values.nodeGroups }}
                       - {{ $nodeGroup.id | quote }}
                         {{- end }}
+                  {{- end }}
       {{- end }}
       serviceAccountName: {{ include "docker-template.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
@@ -459,6 +461,12 @@ spec:
               readOnly: true
           {{ end }}
           {{ end }}
+          {{- if .Values.hostVolumeMounts.enabled }}
+          {{- range .Values.hostVolumeMounts.volumes }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+          {{- end }}
+          {{ end }}
         {{ end }}
         {{- if .Values.cloudsql.enabled }}
         - name: cloud-sql-proxy
@@ -527,7 +535,7 @@ spec:
               {{- end }}
           {{- end }}
       {{ end }}
-      {{ if or .Values.pvc.enabled .Values.multiplePvc.enabled .Values.resources.requests.nvidiaGpu .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.fileSecretMounts.enabled .Values.awsEfsStorage .Values.datadogSocketVolume.enabled }}
+      {{ if or .Values.pvc.enabled .Values.multiplePvc.enabled .Values.resources.requests.nvidiaGpu .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.fileSecretMounts.enabled .Values.awsEfsStorage .Values.datadogSocketVolume.enabled .Values.hostVolumeMounts.enabled }}
       volumes:
         {{ if .Values.datadogSocketVolume.enabled }}
         - hostPath:
@@ -584,6 +592,14 @@ spec:
           secret:
             secretName: "{{ .secretName }}"
         {{ end }}
+        {{ end }}
+        {{- if .Values.hostVolumeMounts.enabled }}
+        {{- range .Values.hostVolumeMounts.volumes }}
+        - name: {{ .name }}
+          hostPath:
+            path: {{ .hostPath }}
+            type: {{ .type | default "DirectoryOrCreate" }}
+        {{- end }}
         {{ end }}
       {{ end }}
 {{- end }}

--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -461,12 +461,10 @@ spec:
               readOnly: true
           {{ end }}
           {{ end }}
-          {{- if .Values.hostVolumeMounts.enabled }}
-          {{- range .Values.hostVolumeMounts.volumes }}
+          {{- range .Values.hostVolumeMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
           {{- end }}
-          {{ end }}
         {{ end }}
         {{- if .Values.cloudsql.enabled }}
         - name: cloud-sql-proxy
@@ -535,7 +533,7 @@ spec:
               {{- end }}
           {{- end }}
       {{ end }}
-      {{ if or .Values.pvc.enabled .Values.multiplePvc.enabled .Values.resources.requests.nvidiaGpu .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.fileSecretMounts.enabled .Values.awsEfsStorage .Values.datadogSocketVolume.enabled .Values.hostVolumeMounts.enabled }}
+      {{ if or .Values.pvc.enabled .Values.multiplePvc.enabled .Values.resources.requests.nvidiaGpu .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.fileSecretMounts.enabled .Values.awsEfsStorage .Values.datadogSocketVolume.enabled .Values.hostVolumeMounts }}
       volumes:
         {{ if .Values.datadogSocketVolume.enabled }}
         - hostPath:
@@ -593,13 +591,11 @@ spec:
             secretName: "{{ .secretName }}"
         {{ end }}
         {{ end }}
-        {{- if .Values.hostVolumeMounts.enabled }}
-        {{- range .Values.hostVolumeMounts.volumes }}
+        {{- range .Values.hostVolumeMounts }}
         - name: {{ .name }}
           hostPath:
             path: {{ .hostPath }}
             type: {{ .type | default "DirectoryOrCreate" }}
         {{- end }}
-        {{ end }}
       {{ end }}
 {{- end }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -340,16 +340,14 @@ deploymentStrategy:
 
 # Host volume mounts for mounting host directories into containers
 # Format: hostVolumeMounts: [{name: <NAME>, hostPath: <HOST_PATH>, mountPath: <CONTAINER_PATH>, type: <HOSTPATH_TYPE>},..]
-hostVolumeMounts:
-  enabled: false
-  volumes: []
-  # Example:
-  # volumes:
-  #   - name: nvme-storage
-  #     hostPath: /mnt/nvme-shared
-  #     mountPath: /tmp/nvme
-  #     type: DirectoryOrCreate
-  #   - name: docker-socket
-  #     hostPath: /var/run/docker.sock
-  #     mountPath: /var/run/docker.sock
-  #     type: Socket
+hostVolumeMounts: []
+# Example:
+# hostVolumeMounts:
+#   - name: nvme-storage
+#     hostPath: /mnt/nvme-shared
+#     mountPath: /tmp/nvme
+#     type: DirectoryOrCreate
+#   - name: docker-socket
+#     hostPath: /var/run/docker.sock
+#     mountPath: /var/run/docker.sock
+#     type: Socket

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -337,3 +337,19 @@ deploymentStrategy:
     maxUnavailable: 25%
   # blueGreen:
   #   group: ""
+
+# Host volume mounts for mounting host directories into containers
+# Format: hostVolumeMounts: [{name: <NAME>, hostPath: <HOST_PATH>, mountPath: <CONTAINER_PATH>, type: <HOSTPATH_TYPE>},..]
+hostVolumeMounts:
+  enabled: false
+  volumes: []
+  # Example:
+  # volumes:
+  #   - name: nvme-storage
+  #     hostPath: /mnt/nvme-shared
+  #     mountPath: /tmp/nvme
+  #     type: DirectoryOrCreate
+  #   - name: docker-socket
+  #     hostPath: /var/run/docker.sock
+  #     mountPath: /var/run/docker.sock
+  #     type: Socket

--- a/applications/worker/templates/_helpers.tpl
+++ b/applications/worker/templates/_helpers.tpl
@@ -101,7 +101,7 @@ For backwards compatibility, this concatenates targets from cloudsql.connectionN
 Return true if volumeMounts should be rendered in the main container
 */}}
 {{- define "worker.shouldRenderVolumeMounts" -}}
-{{- if or .Values.datadogSocketVolume.enabled .Values.pvc.enabled .Values.multiplePvc.enabled .Values.emptyDir.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) .Values.additionalVolumes -}}
+{{- if or .Values.datadogSocketVolume.enabled .Values.pvc.enabled .Values.multiplePvc.enabled .Values.emptyDir.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) .Values.hostVolumeMounts.enabled .Values.additionalVolumes -}}
 true
 {{- else -}}
 false

--- a/applications/worker/templates/_helpers.tpl
+++ b/applications/worker/templates/_helpers.tpl
@@ -101,7 +101,7 @@ For backwards compatibility, this concatenates targets from cloudsql.connectionN
 Return true if volumeMounts should be rendered in the main container
 */}}
 {{- define "worker.shouldRenderVolumeMounts" -}}
-{{- if or .Values.datadogSocketVolume.enabled .Values.pvc.enabled .Values.multiplePvc.enabled .Values.emptyDir.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) .Values.hostVolumeMounts.enabled .Values.additionalVolumes -}}
+{{- if or .Values.datadogSocketVolume.enabled .Values.pvc.enabled .Values.multiplePvc.enabled .Values.emptyDir.enabled (and .Values.fileSecretMounts .Values.fileSecretMounts.enabled) .Values.hostVolumeMounts .Values.additionalVolumes -}}
 true
 {{- else -}}
 false

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -346,6 +346,12 @@ spec:
               mountPath: {{ .mountPath }}
             {{ end }}
             {{ end }}
+            {{- if .Values.hostVolumeMounts.enabled }}
+            {{- range .Values.hostVolumeMounts.volumes }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
+            {{ end }}
         {{ end }}
         {{- if .Values.cloudsql.enabled }}
         - name: cloud-sql-proxy
@@ -414,7 +420,7 @@ spec:
               {{- end }}
           {{- end }}
       {{ end }}
-      {{ if or .Values.pvc.enabled .Values.multiplePvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.datadogSocketVolume.enabled .Values.fileSecretMounts.enabled (and .Values.additionalVolumes (not (empty .Values.additionalVolumes))) }}
+      {{ if or .Values.pvc.enabled .Values.multiplePvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.datadogSocketVolume.enabled .Values.fileSecretMounts.enabled .Values.hostVolumeMounts.enabled (and .Values.additionalVolumes (not (empty .Values.additionalVolumes))) }}
       volumes:
         {{ if .Values.datadogSocketVolume.enabled }}
         - hostPath:
@@ -464,6 +470,14 @@ spec:
         - name: {{ .name }}
           {{ .type }}:
             {{- toYaml .volumeOptions | nindent 12 }}
+        {{- end }}
+        {{ end }}
+        {{- if .Values.hostVolumeMounts.enabled }}
+        {{- range .Values.hostVolumeMounts.volumes }}
+        - name: {{ .name }}
+          hostPath:
+            path: {{ .hostPath }}
+            type: {{ .type | default "DirectoryOrCreate" }}
         {{- end }}
         {{ end }}
       {{ end }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -346,7 +346,7 @@ spec:
               mountPath: {{ .mountPath }}
             {{ end }}
             {{ end }}
-            {{- range .Values.hostVolumeMounts }}
+            {{ range .Values.hostVolumeMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
             {{- end }}

--- a/applications/worker/templates/deployment.yaml
+++ b/applications/worker/templates/deployment.yaml
@@ -346,12 +346,10 @@ spec:
               mountPath: {{ .mountPath }}
             {{ end }}
             {{ end }}
-            {{- if .Values.hostVolumeMounts.enabled }}
-            {{- range .Values.hostVolumeMounts.volumes }}
+            {{- range .Values.hostVolumeMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
             {{- end }}
-            {{ end }}
         {{ end }}
         {{- if .Values.cloudsql.enabled }}
         - name: cloud-sql-proxy
@@ -420,7 +418,7 @@ spec:
               {{- end }}
           {{- end }}
       {{ end }}
-      {{ if or .Values.pvc.enabled .Values.multiplePvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.datadogSocketVolume.enabled .Values.fileSecretMounts.enabled .Values.hostVolumeMounts.enabled (and .Values.additionalVolumes (not (empty .Values.additionalVolumes))) }}
+      {{ if or .Values.pvc.enabled .Values.multiplePvc.enabled .Values.cloudsql.enabled .Values.emptyDir.enabled .Values.datadogSocketVolume.enabled .Values.fileSecretMounts.enabled .Values.hostVolumeMounts (and .Values.additionalVolumes (not (empty .Values.additionalVolumes))) }}
       volumes:
         {{ if .Values.datadogSocketVolume.enabled }}
         - hostPath:
@@ -472,12 +470,10 @@ spec:
             {{- toYaml .volumeOptions | nindent 12 }}
         {{- end }}
         {{ end }}
-        {{- if .Values.hostVolumeMounts.enabled }}
-        {{- range .Values.hostVolumeMounts.volumes }}
+        {{- range .Values.hostVolumeMounts }}
         - name: {{ .name }}
           hostPath:
             path: {{ .hostPath }}
             type: {{ .type | default "DirectoryOrCreate" }}
         {{- end }}
-        {{ end }}
       {{ end }}

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -194,6 +194,22 @@ fileSecretMounts:
   enabled: false
   mounts: []
 
+# Host volume mounts for mounting host directories into containers
+# Format: hostVolumeMounts: [{name: <NAME>, hostPath: <HOST_PATH>, mountPath: <CONTAINER_PATH>, type: <HOSTPATH_TYPE>},..]
+hostVolumeMounts:
+  enabled: false
+  volumes: []
+  # Example:
+  # volumes:
+  #   - name: nvme-storage
+  #     hostPath: /mnt/nvme-shared
+  #     mountPath: /tmp/nvme
+  #     type: DirectoryOrCreate
+  #   - name: docker-socket
+  #     hostPath: /var/run/docker.sock
+  #     mountPath: /var/run/docker.sock
+  #     type: Socket
+
 # set this to add additional volumes to the deployment
 additionalVolumes:
   # - name: ""

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -196,19 +196,17 @@ fileSecretMounts:
 
 # Host volume mounts for mounting host directories into containers
 # Format: hostVolumeMounts: [{name: <NAME>, hostPath: <HOST_PATH>, mountPath: <CONTAINER_PATH>, type: <HOSTPATH_TYPE>},..]
-hostVolumeMounts:
-  enabled: false
-  volumes: []
-  # Example:
-  # volumes:
-  #   - name: nvme-storage
-  #     hostPath: /mnt/nvme-shared
-  #     mountPath: /tmp/nvme
-  #     type: DirectoryOrCreate
-  #   - name: docker-socket
-  #     hostPath: /var/run/docker.sock
-  #     mountPath: /var/run/docker.sock
-  #     type: Socket
+hostVolumeMounts: []
+# Example:
+# hostVolumeMounts:
+#   - name: nvme-storage
+#     hostPath: /mnt/nvme-shared
+#     mountPath: /tmp/nvme
+#     type: DirectoryOrCreate
+#   - name: docker-socket
+#     hostPath: /var/run/docker.sock
+#     mountPath: /var/run/docker.sock
+#     type: Socket
 
 # set this to add additional volumes to the deployment
 additionalVolumes:


### PR DESCRIPTION
Adds a `hostVolumeMounts` option that will allow specifying porter apps such that they can be configured to mount files directly from the host filesystem. This is important to support low latency use cases. 