### PR TITLE
feat: keda trigger auth template for Porter apps

### DIFF
--- a/applications/web/templates/scaled-object.yaml
+++ b/applications/web/templates/scaled-object.yaml
@@ -48,13 +48,14 @@ spec:
   {{- if .Values.keda.triggers }}
   triggers:
   {{- range .Values.keda.triggers }}
-    - type: {{ .type }}
-      {{- if .authenticationRef }}
+    {{/* Render all trigger fields while processing authenticationRef to reference TriggerAuthentication resources */}}
+    {{- $authRef := .authenticationRef }}
+    {{- $triggerCopy := omit . "authenticationRef" }}
+    - {{- toYaml $triggerCopy | nindent 6 }}
+      {{- if $authRef }}
       authenticationRef:
-        name: {{ $fullName }}-{{ .authenticationRef }}
+        name: {{ $fullName }}-{{ $authRef }}
       {{- end }}
-      metadata:
-      {{- toYaml .metadata | nindent 8 }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/applications/web/templates/scaled-object.yaml
+++ b/applications/web/templates/scaled-object.yaml
@@ -47,6 +47,14 @@ spec:
   {{- end }}
   {{- if .Values.keda.triggers }}
   triggers:
-  {{- toYaml .Values.keda.triggers | nindent 4 }}
+  {{- range .Values.keda.triggers }}
+    - type: {{ .type }}
+      {{- if .authenticationRef }}
+      authenticationRef:
+        name: {{ $fullName }}-{{ .authenticationRef }}
+      {{- end }}
+      metadata:
+      {{- toYaml .metadata | nindent 8 }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/applications/web/templates/trigger-authentication.yaml
+++ b/applications/web/templates/trigger-authentication.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.keda.enabled .Values.keda.authentications -}}
+{{- $fullName := include "docker-template.fullname" . -}}
+{{- range $authName, $authConfig := .Values.keda.authentications }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ $fullName }}-{{ $authName }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  {{- if $authConfig.apiKey }}
+  secretTargetRef:
+    - parameter: apiKey
+      name: {{ $authConfig.apiKey.secretName }}
+      key: {{ $authConfig.apiKey.secretKey }}
+  {{- end }}
+  {{- if $authConfig.secretRefs }}
+  secretTargetRef:
+  {{- range $authConfig.secretRefs }}
+    - parameter: {{ .parameter }}
+      name: {{ .secretName }}
+      key: {{ .secretKey }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -175,6 +175,33 @@ keda:
     metricQuery: ""
     metricThreshold: ""
   triggers: []
+    # Example Temporal trigger with authentication:
+    # - type: temporal
+    #   authenticationRef: temporal-auth
+    #   metadata:
+    #     endpoint: temporal-frontend.temporal.svc.cluster.local:7233
+    #     namespace: default
+    #     taskQueue: my-workflow-queue
+    #     targetQueueSize: "5"
+    #     queueTypes: workflow,activity
+
+  # Named authentication configurations that can be referenced by triggers
+  authentications: {}
+    # Example for Temporal Cloud API key:
+    # temporal-auth:
+    #   apiKey:
+    #     secretName: temporal-secret
+    #     secretKey: api-key
+    #
+    # Example for custom secret refs:
+    # custom-auth:
+    #   secretRefs:
+    #     - parameter: username
+    #       secretName: my-secret
+    #       secretKey: username
+    #     - parameter: password
+    #       secretName: my-secret
+    #       secretKey: password
 
 health:
   livenessProbe:

--- a/applications/worker/templates/scaled-object.yaml
+++ b/applications/worker/templates/scaled-object.yaml
@@ -48,6 +48,14 @@ spec:
   {{- end }}
   {{- if .Values.keda.triggers }}
   triggers:
-  {{- toYaml .Values.keda.triggers | nindent 4 }}
+  {{- range .Values.keda.triggers }}
+    - type: {{ .type }}
+      {{- if .authenticationRef }}
+      authenticationRef:
+        name: {{ $fullName }}-{{ .authenticationRef }}
+      {{- end }}
+      metadata:
+      {{- toYaml .metadata | nindent 8 }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/applications/worker/templates/scaled-object.yaml
+++ b/applications/worker/templates/scaled-object.yaml
@@ -49,13 +49,14 @@ spec:
   {{- if .Values.keda.triggers }}
   triggers:
   {{- range .Values.keda.triggers }}
-    - type: {{ .type }}
-      {{- if .authenticationRef }}
+    {{/* Render all trigger fields while processing authenticationRef to reference TriggerAuthentication resources */}}
+    {{- $authRef := .authenticationRef }}
+    {{- $triggerCopy := omit . "authenticationRef" }}
+    - {{- toYaml $triggerCopy | nindent 6 }}
+      {{- if $authRef }}
       authenticationRef:
-        name: {{ $fullName }}-{{ .authenticationRef }}
+        name: {{ $fullName }}-{{ $authRef }}
       {{- end }}
-      metadata:
-      {{- toYaml .metadata | nindent 8 }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/applications/worker/templates/trigger-authentication.yaml
+++ b/applications/worker/templates/trigger-authentication.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.keda.enabled .Values.keda.authentications -}}
+{{- $fullName := include "docker-template.fullname" . -}}
+{{- range $authName, $authConfig := .Values.keda.authentications }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ $fullName }}-{{ $authName }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  {{- if $authConfig.apiKey }}
+  secretTargetRef:
+    - parameter: apiKey
+      name: {{ $authConfig.apiKey.secretName }}
+      key: {{ $authConfig.apiKey.secretKey }}
+  {{- end }}
+  {{- if $authConfig.secretRefs }}
+  secretTargetRef:
+  {{- range $authConfig.secretRefs }}
+    - parameter: {{ .parameter }}
+      name: {{ .secretName }}
+      key: {{ .secretKey }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -104,6 +104,33 @@ keda:
     metricQuery: ""
     metricThreshold: ""
   triggers: []
+    # Example Temporal trigger with authentication:
+    # - type: temporal
+    #   authenticationRef: temporal-auth
+    #   metadata:
+    #     endpoint: temporal-frontend.temporal.svc.cluster.local:7233
+    #     namespace: default
+    #     taskQueue: my-workflow-queue
+    #     targetQueueSize: "5"
+    #     queueTypes: workflow,activity
+
+  # Named authentication configurations that can be referenced by triggers
+  authentications: {}
+    # Example for Temporal Cloud API key:
+    # temporal-auth:
+    #   apiKey:
+    #     secretName: temporal-secret
+    #     secretKey: api-key
+    #
+    # Example for custom secret refs:
+    # custom-auth:
+    #   secretRefs:
+    #     - parameter: username
+    #       secretName: my-secret
+    #       secretKey: username
+    #     - parameter: password
+    #       secretName: my-secret
+    #       secretKey: password
 
 health:
   enabled: false


### PR DESCRIPTION
A lot of KEDA triggers like Temporal require authentication. This has two parts: declaring a `TriggerAuthentication` type object and then referencing it from the triggers in the ScaledObject. This PR sets up the web and worker charts to enable such a scaler. 