### PR TITLE
Feat: Metabase HA + node group selector

### DIFF
--- a/addons/metabase/templates/deployment.yaml
+++ b/addons/metabase/templates/deployment.yaml
@@ -58,16 +58,16 @@ spec:
                   fieldPath: status.podIP
             - name: PORTER_POD_IMAGE_TAG
               value: "{{ .Values.image.tag }}"
-            {{- range $key, $val := .Values.container.env.normal }}
-            - name: {{ $key }}
-            {{- $splVal := split "_" $val -}}
+            {{- range $env := .Values.container.env.normal }}
+            - name: {{ $env.name }}
+            {{- $splVal := split "_" $env.value -}}
             {{- if and (len $splVal | eq 2) (eq $splVal._0 "PORTERSECRET") }}
               valueFrom:
                 secretKeyRef:
                   name: {{ $splVal._1 }}
-                  key: {{ $key }}
+                  key: {{ $env.namekey }}
             {{- else }}
-              value: {{ quote $val }}
+              value: {{ quote $env.value }}
             {{- end }}
             {{- end }}
             {{- if or (eq .Values.image.repository "porterdev/hello-porter") (eq .Values.image.repository "public.ecr.aws/o1j4x7p4/hello-porter") }}

--- a/addons/metabase/templates/deployment.yaml
+++ b/addons/metabase/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       labels:
         {{- include "docker-template.selectorLabels" . | nindent 8 }}
     spec:
+      nodeSelector:
+        {{- range $ns := .Values.nodeSelector }}
+        {{ $ns.label }}: {{ $ns.value }}
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/addons/metabase/templates/deployment.yaml
+++ b/addons/metabase/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "docker-template.labels" . | nindent 4 }}
 spec:
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "docker-template.selectorLabels" . | nindent 6 }}

--- a/addons/metabase/templates/deployment.yaml
+++ b/addons/metabase/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ $splVal._1 }}
-                  key: {{ $env.namekey }}
+                  key: {{ $env.name }}
             {{- else }}
               value: {{ quote $env.value }}
             {{- end }}

--- a/addons/metabase/values.yaml
+++ b/addons/metabase/values.yaml
@@ -61,3 +61,7 @@ resources:
   requests:
     cpu: 500m
     memory: 512Mi
+
+nodeSelector:
+  - label: porter.run/workload-kind
+    value: application

--- a/addons/metabase/values.yaml
+++ b/addons/metabase/values.yaml
@@ -52,10 +52,11 @@ privateIngress:
 container:
   port: 3000
   env: 
-    # - name: NODE_ENV
-    #   value: development
-    # - name: OK
-    #   value: ok
+    normal:
+      # - name: NODE_ENV
+      #   value: development
+      # - name: ENV_VAR
+      #   value: PORTERSECRET_secret-name
 
 resources:
   requests:


### PR DESCRIPTION
As requested by the user, this PR modifies the Metabase Helm chart to:
- allow multiple replicas;
- allow selecting nodes (group) by node label;

Also, this fixes the container template logic by adding the field `.normal` to the `container.env` field of the chart values.