### PR TITLE
Fix: Metabase's add-on env var handling

### DIFF
--- a/addons/metabase/templates/deployment.yaml
+++ b/addons/metabase/templates/deployment.yaml
@@ -58,19 +58,18 @@ spec:
                   fieldPath: status.podIP
             - name: PORTER_POD_IMAGE_TAG
               value: "{{ .Values.image.tag }}"
-            {{- range $env := .Values.container.env.normal }}
-            - name: {{ $env.name }}
-            {{- $splVal := split "_" $env.value -}}
+            {{- range $key, $val := .Values.container.env.normal }}
+            - name: {{ $key }}
+            {{- $splVal := split "_" $val -}}
             {{- if and (len $splVal | eq 2) (eq $splVal._0 "PORTERSECRET") }}
               valueFrom:
                 secretKeyRef:
                   name: {{ $splVal._1 }}
-                  key: {{ $env.name }}
+                  key: {{ $key }}
             {{- else }}
-              value: {{ quote $env.value }}
+              value: {{ quote $val }}
             {{- end }}
-            {{- end }}
-            {{- if or (eq .Values.image.repository "porterdev/hello-porter") (eq .Values.image.repository "public.ecr.aws/o1j4x7p4/hello-porter") }}
+            {{- end }}            {{- if or (eq .Values.image.repository "porterdev/hello-porter") (eq .Values.image.repository "public.ecr.aws/o1j4x7p4/hello-porter") }}
             - name: PORT
               value: {{ .Values.container.port | quote }}
             {{- end }}

--- a/addons/metabase/values.yaml
+++ b/addons/metabase/values.yaml
@@ -53,10 +53,8 @@ container:
   port: 3000
   env: 
     normal:
-      # - name: NODE_ENV
-      #   value: development
-      # - name: ENV_VAR
-      #   value: PORTERSECRET_secret-name
+      # NODE_ENV: development
+      # ENV: PORTERSECRET_ENV
 
 resources:
   requests:


### PR DESCRIPTION
This reverts a breaking change introduced in the latest version of the add-on. When using the latest version, users who had env vars in the format:
```
- NODE_ENV: development
- ENV_VAR: PORTERSECRET_secret-name
```
would see an error like:
```
template: metabase/templates/deployment.yaml:62:27: executing "metabase/templates/deployment-yaml" at <$env. name>: can't evaluate field name in type interface {}
```

The latest version would require users to present env vars like:
```
- name: NODE_ENV
  value: development
- name: ENV_VAR
  value: PORTERSECRET_secret-name
```

With the present change, users can maintain the previous format.