### PR TITLE
fix: prevent karpenter from evicting rollout-sync pods

### DIFF
--- a/applications/web/templates/deployment-analysis-template.yaml
+++ b/applications/web/templates/deployment-analysis-template.yaml
@@ -16,6 +16,8 @@ spec:
         spec:
           template:
             metadata:
+              annotations:
+                karpenter.sh/do-not-disrupt: "true"
               labels:
                 porter.run/app-name: {{ .Release.Name }}
                 porter.run/service-name: {{ include "docker-template.fullname" . }}


### PR DESCRIPTION
## Description

Deploys for blue-green apps are intermittently getting aborted because Karpenter evicts the short-lived `rollout-sync` job pod mid-flight with reason `Underutilized`. Once that pod goes away, the Job hits its backoff limit, the AnalysisRun fails, and the Rollout aborts revision. When the aborted app is one half of a partner group, the other partner sits "healthy" waiting for a `ready` signal that never comes, and after 20 minutes the backend scheduler marks the whole group fatal. Users see apps go healthy for 20 minutes and then get cancelled, with no useful error.

Seen in the wild on `crunched-web-addin` in the crunched prod cluster today: rev 17, 21, and 22 all failed the same way. Cluster events: `Evicted pod: Underutilized` -> `Stopping container rollout-sync` -> `BackoffLimitExceeded` -> `AnalysisRunFailed` -> `RolloutAborted`. The paired `crunched-api` happens to finish fast enough (~95s) to dodge consolidation, which is why only one of the two apps kept stalling.

The fix is to mark the rollout-sync job pod with `karpenter.sh/do-not-disrupt: "true"` so Karpenter leaves it alone for its short life. The job is a coordination primitive - there's no benefit to letting it be consolidated, and the cost is a busted deploy. I considered bumping `backoffLimit` / `failureLimit` instead, but that only masks the eviction and still loses all progress on restart. The do-not-disrupt annotation is the correct signal for "this pod is load-bearing, don't move it."

## Summary of Changes

- Add `karpenter.sh/do-not-disrupt: "true"` to the rollout-sync job pod template in the web chart's AnalysisTemplate

## Extra Notes

Only the `web` chart has an AnalysisTemplate (blue-green is web-only), so no equivalent change is needed in `worker` or `job`.