### PR TITLE
Add NetworkPolicy support to application charts

### DIFF
--- a/applications/job/templates/networkpolicy.yaml
+++ b/applications/job/templates/networkpolicy.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "docker-template.fullname" . }}
+  labels:
+    {{- include "docker-template.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "docker-template.selectorLabels" . | nindent 6 }}
+  {{- if .Values.networkPolicy.policyTypes }}
+  policyTypes:
+    {{- toYaml .Values.networkPolicy.policyTypes | nindent 4 }}
+  {{- else }}
+  policyTypes:
+    {{- if .Values.networkPolicy.ingress }}
+    - Ingress
+    {{- end }}
+    {{- if .Values.networkPolicy.egress }}
+    - Egress
+    {{- end }}
+  {{- end }}
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+  {{- end }}
+  {{- if .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/applications/job/values.yaml
+++ b/applications/job/values.yaml
@@ -124,6 +124,28 @@ fileSecretMounts:
   enabled: false
   mounts: []
 
+networkPolicy:
+  enabled: false
+  # policyTypes defaults to the types implied by the rules below.
+  # Explicitly set to ["Ingress"], ["Egress"], or ["Ingress", "Egress"] to override.
+  policyTypes: []
+  ingress: []
+    # - from:
+    #     - podSelector:
+    #         matchLabels:
+    #           app: frontend
+    #   ports:
+    #     - protocol: TCP
+    #       port: 80
+  egress: []
+    # - to:
+    #     - podSelector:
+    #         matchLabels:
+    #           app: database
+    #   ports:
+    #     - protocol: TCP
+    #       port: 5432
+
 # Host volume mounts for mounting host directories into containers
 # Format: hostVolumeMounts: [{name: <NAME>, hostPath: <HOST_PATH>, mountPath: <CONTAINER_PATH>, type: <HOSTPATH_TYPE>},..]
 hostVolumeMounts: []

--- a/applications/web/templates/networkpolicy.yaml
+++ b/applications/web/templates/networkpolicy.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "docker-template.fullname" . }}
+  labels:
+    {{- include "docker-template.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "docker-template.selectorLabels" . | nindent 6 }}
+  {{- if .Values.networkPolicy.policyTypes }}
+  policyTypes:
+    {{- toYaml .Values.networkPolicy.policyTypes | nindent 4 }}
+  {{- else }}
+  policyTypes:
+    {{- if .Values.networkPolicy.ingress }}
+    - Ingress
+    {{- end }}
+    {{- if .Values.networkPolicy.egress }}
+    - Egress
+    {{- end }}
+  {{- end }}
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+  {{- end }}
+  {{- if .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/applications/web/values.yaml
+++ b/applications/web/values.yaml
@@ -410,6 +410,33 @@ deploymentStrategy:
   # blueGreen:
   #   group: ""
 
+networkPolicy:
+  enabled: false
+  # policyTypes defaults to the types implied by the rules below.
+  # Explicitly set to ["Ingress"], ["Egress"], or ["Ingress", "Egress"] to override.
+  policyTypes: []
+  ingress: []
+    # - from:
+    #     - podSelector:
+    #         matchLabels:
+    #           app: frontend
+    #     - namespaceSelector:
+    #         matchLabels:
+    #           name: monitoring
+    #     - ipBlock:
+    #         cidr: 10.0.0.0/8
+    #   ports:
+    #     - protocol: TCP
+    #       port: 80
+  egress: []
+    # - to:
+    #     - podSelector:
+    #         matchLabels:
+    #           app: database
+    #   ports:
+    #     - protocol: TCP
+    #       port: 5432
+
 # Host volume mounts for mounting host directories into containers
 # Format: hostVolumeMounts: [{name: <NAME>, hostPath: <HOST_PATH>, mountPath: <CONTAINER_PATH>, type: <HOSTPATH_TYPE>},..]
 hostVolumeMounts: []

--- a/applications/worker/templates/networkpolicy.yaml
+++ b/applications/worker/templates/networkpolicy.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "docker-template.fullname" . }}
+  labels:
+    {{- include "docker-template.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "docker-template.selectorLabels" . | nindent 6 }}
+  {{- if .Values.networkPolicy.policyTypes }}
+  policyTypes:
+    {{- toYaml .Values.networkPolicy.policyTypes | nindent 4 }}
+  {{- else }}
+  policyTypes:
+    {{- if .Values.networkPolicy.ingress }}
+    - Ingress
+    {{- end }}
+    {{- if .Values.networkPolicy.egress }}
+    - Egress
+    {{- end }}
+  {{- end }}
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+  {{- end }}
+  {{- if .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/applications/worker/values.yaml
+++ b/applications/worker/values.yaml
@@ -275,6 +275,31 @@ fileSecretMounts:
   enabled: false
   mounts: []
 
+networkPolicy:
+  enabled: false
+  # policyTypes defaults to the types implied by the rules below.
+  # Explicitly set to ["Ingress"], ["Egress"], or ["Ingress", "Egress"] to override.
+  policyTypes: []
+  ingress: []
+    # - from:
+    #     - podSelector:
+    #         matchLabels:
+    #           app: frontend
+    #     - namespaceSelector:
+    #         matchLabels:
+    #           name: monitoring
+    #   ports:
+    #     - protocol: TCP
+    #       port: 80
+  egress: []
+    # - to:
+    #     - podSelector:
+    #         matchLabels:
+    #           app: database
+    #   ports:
+    #     - protocol: TCP
+    #       port: 5432
+
 # Host volume mounts for mounting host directories into containers
 # Format: hostVolumeMounts: [{name: <NAME>, hostPath: <HOST_PATH>, mountPath: <CONTAINER_PATH>, type: <HOSTPATH_TYPE>},..]
 hostVolumeMounts: []


### PR DESCRIPTION
## Summary
- Adds a `networkPolicy` configuration block to the **job**, **web**, and **worker** Helm charts
- Disabled by default (`networkPolicy.enabled: false`) — no impact on existing deployments
- Users can define raw Kubernetes NetworkPolicy `ingress` and `egress` rules via Helm values, with automatic `policyTypes` inference or explicit override

## Test plan
- [x] `helm template` renders valid NetworkPolicy with ingress-only, egress-only, and combined rules
- [x] No output when `networkPolicy.enabled: false` (default)
- [x] Explicit `policyTypes` override works correctly
- [ ] Deploy to a test cluster with a CNI that enforces NetworkPolicies (e.g., Calico, Cilium)

🤖 Generated with [Claude Code](https://claude.com/claude-code)