### PR TITLE
feat: respect podSecurityContext and securityContext in job chart

### DIFF
--- a/applications/job/templates/cronjob.yaml
+++ b/applications/job/templates/cronjob.yaml
@@ -79,6 +79,8 @@ spec:
               {{- end }}
           {{- end }}
           serviceAccountName: {{ include "docker-template.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
           {{- if and .Values.image .Values.image.imagePullSecret }}
           imagePullSecrets:
             - name: {{ .Values.image.imagePullSecret }}
@@ -91,6 +93,8 @@ spec:
           {{- end }}
           containers:
             - name: {{ .Chart.Name }}
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 16 }}
             {{- if .Values.global }}
             {{- if .Values.global.image }}
               image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"

--- a/applications/job/templates/hook-configmap.yaml
+++ b/applications/job/templates/hook-configmap.yaml
@@ -58,6 +58,8 @@ data:
               value: "true"
               effect: "NoSchedule"
           serviceAccountName: {{ include "docker-template.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
           {{- if or .Values.enableEDNS0 .Values.ndots }}
           dnsConfig:
             options:
@@ -75,6 +77,8 @@ data:
           {{- end }}
           containers:
           - name: {{ .Chart.Name }}
+            securityContext:
+              {{- toYaml .Values.securityContext | nindent 14 }}
             {{- if .Values.global }}
             {{- if .Values.global.image }}
             image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"


### PR DESCRIPTION
## Summary
- Adds pod-level and container-level \`securityContext\` rendering from \`.Values.podSecurityContext\` and \`.Values.securityContext\` in the job chart's \`cronjob.yaml\` and \`hook-configmap.yaml\`, matching existing web/worker behavior.
- Allows users to set \`seccompProfile\` (and other security context fields) on job workloads.

## Test plan
- [x] \`helm lint applications/job\` passes
- [x] \`helm template\` with no overrides renders \`securityContext: null\` (matches worker default behavior)
- [x] \`helm template\` with \`podSecurityContext.seccompProfile.type=RuntimeDefault\` and \`securityContext.seccompProfile.type=RuntimeDefault\` renders the values correctly at both pod and container level in cronjob.yaml and the embedded one-off Job in hook-configmap.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)