### PR TITLE
feat: pin image digests for Tier 1 addon charts

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -429,7 +429,7 @@ jobs:
         shell: bash
         run: |
           OUT=$(helm template addons/redis)
-          echo "$OUT" | grep -qE "porterhub/redis-managed.*@sha256:" \
+          grep -qE "porterhub/redis-managed.*@sha256:" <<< "$OUT" \
             || (echo "redis image is not digest-pinned" && exit 1)
 
       - name: Addon digest pinning - logdna
@@ -437,7 +437,7 @@ jobs:
         shell: bash
         run: |
           OUT=$(helm template addons/logdna --set logdna.key=test-key)
-          echo "$OUT" | grep -qE "logdna/logdna-agent.*@sha256:" \
+          grep -qE "logdna/logdna-agent.*@sha256:" <<< "$OUT" \
             || (echo "logdna image is not digest-pinned" && exit 1)
 
       - name: Addon digest pinning - grafana
@@ -449,7 +449,7 @@ jobs:
             --set sidecar.dashboards.enabled=true \
             --set initChownData.enabled=true)
           for img in "grafana/grafana" "curlimages/curl" "library/busybox" "kiwigrid/k8s-sidecar"; do
-            echo "$OUT" | grep -qE "${img}.*@sha256:" \
+            grep -qE "${img}.*@sha256:" <<< "$OUT" \
               || (echo "grafana: ${img} image is not digest-pinned" && exit 1)
           done
 
@@ -462,7 +462,7 @@ jobs:
             --set clusterChecksRunner.enabled=true \
             --set fips.enabled=true)
           for img in "datadoghq/cluster-agent" "datadoghq/agent" "datadoghq/fips-proxy"; do
-            echo "$OUT" | grep -qE "${img}.*@sha256:" \
+            grep -qE "${img}.*@sha256:" <<< "$OUT" \
               || (echo "datadog: ${img} image is not digest-pinned" && exit 1)
           done
 
@@ -472,7 +472,7 @@ jobs:
         run: |
           OUT=$(helm template addons/tailscale-operator \
             --set oauth.clientId=test --set oauth.clientSecret=test)
-          echo "$OUT" | grep -qE "tailscale/k8s-operator.*@sha256:" \
+          grep -qE "tailscale/k8s-operator.*@sha256:" <<< "$OUT" \
             || (echo "tailscale-operator: operator image is not digest-pinned" && exit 1)
-          echo "$OUT" | grep -qE "tailscale/tailscale.*@sha256:" \
+          grep -qE "tailscale/tailscale.*@sha256:" <<< "$OUT" \
             || (echo "tailscale-operator: proxy image is not digest-pinned" && exit 1)

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -22,14 +22,24 @@ jobs:
         with:
           files: |
             applications/**
+      - name: Get changed addon files
+        id: changed-files-addons
+        uses: tj-actions/changed-files@v41
+        with:
+          files: |
+            addons/grafana/**
+            addons/redis/**
+            addons/datadog/**
+            addons/tailscale-operator/**
+            addons/logdna/**
       - name: List all changed files
         run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          for file in ${{ steps.changed-files.outputs.all_changed_files }} ${{ steps.changed-files-addons.outputs.all_changed_files }}; do
             echo "$file was changed"
           done
 
       - name: Setup Helm
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.changed-files.outputs.any_changed == 'true' || steps.changed-files-addons.outputs.any_changed == 'true'
         uses: azure/setup-helm@v4.2.0
         id: install-helm
 
@@ -409,3 +419,60 @@ jobs:
             || (echo "Expected secondary-instance as separate positional arg in v2" && exit 1)
           echo "$OUT" | grep -q "primary-instance.*secondary-instance\|secondary-instance.*primary-instance" \
             && (echo "v2 instances must be separate args, not comma-joined on one line" && exit 1) || true
+
+      # --- Addon image digest pinning ---
+      # Verifies each pinned image still renders with an @sha256: digest.
+      # Loose check (no hardcoded hashes) so legitimate digest bumps don't require CI updates.
+
+      - name: Addon digest pinning - redis
+        if: steps.changed-files-addons.outputs.any_changed == 'true'
+        shell: bash
+        run: |
+          OUT=$(helm template addons/redis)
+          echo "$OUT" | grep -qE "porterhub/redis-managed.*@sha256:" \
+            || (echo "redis image is not digest-pinned" && exit 1)
+
+      - name: Addon digest pinning - logdna
+        if: steps.changed-files-addons.outputs.any_changed == 'true'
+        shell: bash
+        run: |
+          OUT=$(helm template addons/logdna --set logdna.key=test-key)
+          echo "$OUT" | grep -qE "logdna/logdna-agent.*@sha256:" \
+            || (echo "logdna image is not digest-pinned" && exit 1)
+
+      - name: Addon digest pinning - grafana
+        if: steps.changed-files-addons.outputs.any_changed == 'true'
+        shell: bash
+        run: |
+          OUT=$(helm template addons/grafana \
+            --set persistence.enabled=true \
+            --set sidecar.dashboards.enabled=true \
+            --set initChownData.enabled=true)
+          for img in "grafana/grafana" "curlimages/curl" "library/busybox" "kiwigrid/k8s-sidecar"; do
+            echo "$OUT" | grep -qE "${img}.*@sha256:" \
+              || (echo "grafana: ${img} image is not digest-pinned" && exit 1)
+          done
+
+      - name: Addon digest pinning - datadog
+        if: steps.changed-files-addons.outputs.any_changed == 'true'
+        shell: bash
+        run: |
+          OUT=$(helm template addons/datadog \
+            --set datadog.apiKey=test \
+            --set clusterChecksRunner.enabled=true \
+            --set fips.enabled=true)
+          for img in "datadoghq/cluster-agent" "datadoghq/agent" "datadoghq/fips-proxy"; do
+            echo "$OUT" | grep -qE "${img}.*@sha256:" \
+              || (echo "datadog: ${img} image is not digest-pinned" && exit 1)
+          done
+
+      - name: Addon digest pinning - tailscale-operator
+        if: steps.changed-files-addons.outputs.any_changed == 'true'
+        shell: bash
+        run: |
+          OUT=$(helm template addons/tailscale-operator \
+            --set oauth.clientId=test --set oauth.clientSecret=test)
+          echo "$OUT" | grep -qE "tailscale/k8s-operator.*@sha256:" \
+            || (echo "tailscale-operator: operator image is not digest-pinned" && exit 1)
+          echo "$OUT" | grep -qE "tailscale/tailscale.*@sha256:" \
+            || (echo "tailscale-operator: proxy image is not digest-pinned" && exit 1)

--- a/addons/datadog/values.yaml
+++ b/addons/datadog/values.yaml
@@ -1252,7 +1252,7 @@ datadog:
       tag: 0.1.11
 
       # datadog.agentDataPlane.image.digest -- Define Agent Data Plane image digest to use, takes precedence over tag if specified
-      digest: ""
+      digest: "sha256:1a2993ec3b12935660ee73b23ebe991726040be9a43c70e03058e061f2ac10e0"
 
       # datadog.agentDataPlane.image.repository -- Override default registry + image.name for Agent Data Plane
       repository:
@@ -1285,7 +1285,7 @@ clusterAgent:
     tag: 7.72.4
 
     # clusterAgent.image.digest -- Cluster Agent image digest to use, takes precedence over tag if specified
-    digest: ""
+    digest: "sha256:755d3ea885ee9bf2b134e417f2e05502425a5bfcfef7fff218e04f0eb089ad90"
 
     # clusterAgent.image.repository -- Override default registry + image.name for Cluster Agent
     repository:
@@ -1804,7 +1804,7 @@ fips:
     pullPolicy: IfNotPresent
 
     # fips.image.digest -- Define the FIPS sidecar image digest to use, takes precedence over `fips.image.tag` if specified.
-    digest: ""
+    digest: "sha256:f44fa24cee53ecafe7ef7eb75b93b256127addf76445973ba7fab5932abc191e"
 
     # fips.image.repository -- Override default registry + image.name for the FIPS sidecar container.
     repository:
@@ -1844,7 +1844,7 @@ agents:
     tag: 7.72.4
 
     # agents.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
-    digest: ""
+    digest: "sha256:560db1ed6d4ec31199af2cf697eff9373977ebc82e6800a555a9a01a3a243179"
 
     # agents.image.tagSuffix -- Suffix to append to Agent tag
 
@@ -2452,7 +2452,7 @@ clusterChecksRunner:
     tag: 7.72.4
 
     # clusterChecksRunner.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
-    digest: ""
+    digest: "sha256:560db1ed6d4ec31199af2cf697eff9373977ebc82e6800a555a9a01a3a243179"
 
     # clusterChecksRunner.image.tagSuffix -- Suffix to append to Agent tag
 
@@ -2921,7 +2921,7 @@ otelAgentGateway:
     tagSuffix: ""
 
     # otelAgentGateway.image.digest -- Override the image digest of otel agent, takes precedence over tag if specified
-    digest: ""
+    digest: "sha256:cbdbee9593535d3382173e3621aaa61a823a8dd7121668517fa00791c604ed51"
 
     # otelAgentGateway.image.repository -- Override the image repository to override default registry
     repository:

--- a/addons/grafana/values.yaml
+++ b/addons/grafana/values.yaml
@@ -101,7 +101,7 @@ image:
   repository: grafana/grafana
   # Overrides the Grafana image tag whose default is the chart appVersion
   tag: ""
-  sha: ""
+  sha: "35c41e0fd0295f5d0ee5db7e780cf33506abfaf47686196f825364889dee878b"
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.
@@ -183,7 +183,7 @@ downloadDashboardsImage:
   registry: docker.io
   repository: curlimages/curl
   tag: 7.85.0
-  sha: ""
+  sha: "9fab1b73f45e06df9506d947616062d7e8319009257d3a05d970b0de80a41ec5"
   pullPolicy: IfNotPresent
 
 downloadDashboards:
@@ -426,7 +426,7 @@ initChownData:
     registry: docker.io
     repository: library/busybox
     tag: "1.31.1"
-    sha: ""
+    sha: "95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209"
     pullPolicy: IfNotPresent
 
   ## initChownData resource requests and limits
@@ -883,7 +883,7 @@ sidecar:
     registry: quay.io
     repository: kiwigrid/k8s-sidecar
     tag: 1.27.4
-    sha: ""
+    sha: "f6ed71d0f9f1175df8c4b8c674b339a74785384d25fdad21b3c3dc0554109286"
   imagePullPolicy: IfNotPresent
   resources: {}
 #   limits:

--- a/addons/logdna/templates/daemon_set.yaml
+++ b/addons/logdna/templates/daemon_set.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Values.logdna.name }}
-        image: "{{ .Values.image.name }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.image.name }}:{{ .Chart.AppVersion }}{{- if .Values.image.sha }}@sha256:{{ .Values.image.sha }}{{- end }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           {{- toYaml .Values.podSecurityContext | nindent 10 }}

--- a/addons/logdna/values.yaml
+++ b/addons/logdna/values.yaml
@@ -1,6 +1,7 @@
 image:
   name: logdna/logdna-agent
   # tag is defined by the appVersion in the Chart file
+  sha: "6c06867bd1a70bc048637a9fc3b98e385511bb7e8056c7f4102fa9797f56f0d0"
   pullPolicy: IfNotPresent
 
 logdna:

--- a/addons/redis/values.yaml
+++ b/addons/redis/values.yaml
@@ -83,7 +83,7 @@ image:
   registry: docker.io
   repository: porterhub/redis-managed
   tag: 7.2.3-debian-11-r2
-  digest: ""
+  digest: "sha256:cae4e1e12b52166698ba032f919bc21c63fc9250cac060cd6fdcf8f92d86fe8b"
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/addons/tailscale-operator/values.yaml
+++ b/addons/tailscale-operator/values.yaml
@@ -45,7 +45,7 @@ operatorConfig:
     # Digest will be prioritized over tag. If neither are set appVersion will be
     # used.
     tag: "v1.84.0"
-    digest: ""
+    digest: "sha256:e6a4645bc1e0f073d9739ee260ff298c856f367e436dd55fe2633fbc92900ff7"
     pullPolicy: Always
   logging: "info" # info, debug, dev
   hostname: "tailscale-operator"
@@ -93,7 +93,7 @@ proxyConfig:
     # Digest will be prioritized over tag. If neither are set appVersion will be
     # used.
     tag: "v1.84.0"
-    digest: ""
+    digest: "sha256:25cadf045d992b7c82f1a006ccda781a67c47ba5d9ee35ce1f9d25319d1bcbc4"
   # ACL tag that operator will tag proxies with. Operator must be made owner of
   # these tags
   # https://tailscale.com/kb/1236/kubernetes-operator/?q=operator#setting-up-the-kubernetes-operator


### PR DESCRIPTION
## Summary

Pins SHA256 image digests in the `values.yaml` of our first set of addon charts to prevent silent tag mutation and supply chain attacks.

**Charts updated:**
- `grafana` — pins main image, curl (init), busybox (initChownData), and k8s-sidecar
- `redis` — pins main porterhub/redis-managed image
- `datadog` — pins agent, cluster-agent, agentDataPlane, fips-proxy, clusterChecksRunner, and otelAgentGateway
- `tailscale-operator` — pins both k8s-operator and tailscale proxy images
- `logdna` (Mezmo) — adds `sha:` field support to daemonset template + pins logdna-agent

All digests were resolved from the live registry and verified against `digests.csv`. Charts were validated with `helm template` to confirm digest appears in the rendered image reference.

## How this works

For charts with a `sha:` field (grafana, logdna): the hex-only digest is set — the chart template internally prepends `sha256:`.
For charts with a `digest:` field (redis, datadog, tailscale): the full `sha256:xxxx` string is set.

## Test plan

- [x] `helm template` verified for all 5 charts — digests appear in rendered image references
- [x] Grafana tested end-to-end in a real Porter cluster (pinned to older digest, pod ran correct image)
- [ ] Logdna to be tested after this chart version is published to ChartMuseum

## Next

Tier 2 (langfuse, n8n, tailscale-relay, postgresql) and Tier 3 (metabase, quivr, hf-llm-models) to follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)