### PR TITLE
feat: expose image fields in local-dns-cache chart (RUN-2547)

### DIFF
--- a/addons/local-dns-cache/Chart.yaml
+++ b/addons/local-dns-cache/Chart.yaml
@@ -4,6 +4,6 @@ description: Enable Node Local DNS cache for faster DNS lookups. (EKS only)
 icon: https://icon-library.com/images/dns-icon/dns-icon-13.jpg
 name: node-local
 type: application
-version: 0.19.0
+version: 0.21.0
 keywords:
   - NETWORKING

--- a/addons/local-dns-cache/templates/localdns.yaml
+++ b/addons/local-dns-cache/templates/localdns.yaml
@@ -139,7 +139,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: k8s.gcr.io/dns/k8s-dns-node-cache:1.17.0
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         resources:
           requests:
             cpu: 25m

--- a/addons/local-dns-cache/values.yaml
+++ b/addons/local-dns-cache/values.yaml
@@ -1,1 +1,5 @@
 clusterDNS: "172.20.0.10"
+
+image:
+  repository: k8s.gcr.io/dns/k8s-dns-node-cache
+  tag: "1.17.0"


### PR DESCRIPTION
## Summary

- Exposes \`image.repository\` and \`image.tag\` in the \`local-dns-cache\` chart's values so callers can override both
- Bumps chart version (deployed is 0.20.0; this PR cuts 0.21.0 so the digest-pinning code in the monolith can target a known-published version)
- Defaults preserve the current image reference (\`k8s.gcr.io/dns/k8s-dns-node-cache:1.17.0\`)

## Why

Required for pinning the \`k8s-dns-node-cache\` image by digest in the porter monolith ([RUN-2547](https://linear.app/porter/issue/RUN-2547/fix-pin-image-versions-for-system-apps)). Today the image is hardcoded in the daemonset template and there's no way to override the tag, so the corresponding monolith change can't pin the digest via the \`<tag>@sha256:<hex>\` pattern used elsewhere.

This PR must merge and the chart must publish before the companion monolith PR lands (the monolith bumps the referenced chartVersion from \`v0.20.0\` to \`v0.21.0\`).

## Test plan

- [ ] Chart publishes to \`chart-addons.porter.run\` as \`node-local v0.21.0\`
- [ ] Render with defaults produces the same daemonset image as today (\`k8s.gcr.io/dns/k8s-dns-node-cache:1.17.0\`)
- [ ] Render with \`--set image.tag="1.17.0@sha256:..."\` produces a digest-pinned image reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)