### PR TITLE
Added initContainerSecurityContext

### DIFF
--- a/applications/web/templates/deployment.yaml
+++ b/applications/web/templates/deployment.yaml
@@ -121,6 +121,8 @@ spec:
       initContainers:
         # this is used for ensuring the kubelet is ready on new nodes, and can injected any downward API keys
         - name: downward-api
+          securityContext:
+      {{- toYaml .Values.initContainerSecurityContext | nindent 12 }}
           env:
           - name: DOWNWARD_API_ENV_KEY
             value: DOWNWARD_HOST_IP


### PR DESCRIPTION
This PR adds configurable securityContext support for the built-in downward-api init container in deployment.yaml.

Previously, only the pod and main application container supported security contexts. Since Kubernetes restricted Pod Security Standards also validate init containers, this allows us to provide compliant initContainerSecurityContext overrides for the init container as well.

For example - 

```
initContainerSecurityContext: 
   allowPrivilegeEscalation: false 
   runAsNonRoot: true
```