### PR TITLE
chore: republish tier 1 addons to ship pinned image digests

### DIFF
--- a/addons/datadog/Chart.yaml
+++ b/addons/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 0.39.0
+version: 0.40.0
 appVersion: "7"
 description: Datadog Agent
 home: https://www.datadoghq.com

--- a/addons/grafana/Chart.yaml
+++ b/addons/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana
-version: 0.12.0
+version: 0.13.0
 appVersion: 12.2.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/addons/logdna/Chart.yaml
+++ b/addons/logdna/Chart.yaml
@@ -20,4 +20,4 @@ name: agent
 sources:
   - https://github.com/logdna/logdna-agent-v2
 type: application
-version: 0.3.0
+version: 0.4.0

--- a/addons/redis/Chart.yaml
+++ b/addons/redis/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
-version: 0.19.0
+version: 0.20.0

--- a/addons/tailscale-operator/Chart.yaml
+++ b/addons/tailscale-operator/Chart.yaml
@@ -15,4 +15,4 @@ name: tailscale-operator
 sources:
   - https://github.com/tailscale/tailscale
 type: application
-version: 0.1.0
+version: 0.2.0


### PR DESCRIPTION
## Summary

[PR #1695](https://github.com/porter-dev/porter-charts/pull/1695) pinned image digests in the values.yaml of five Tier 1 addons (`datadog`, `grafana`, `logdna`, `redis`, `tailscale-operator`), but it merged to `main` at 2026-05-12 15:36:27Z — five minutes before [#1697](https://github.com/porter-dev/porter-charts/pull/1697) flipped the publish workflow from `production` to `main` (15:41:58Z). The workflow never fired for #1695's merge, and the two subsequent runs on `main` (for #1697 and #1696) only diffed their own changed paths, so none of these addons have been republished. Live versions in ChartMuseum still match what was last published from `production` HEAD and don't carry the digest pins.

Bump each affected Chart.yaml so the next publish run detects a diff per chart directory and republishes. The version numbers chosen here are only there to force the diff — `build.sh` queries ChartMuseum for the current published version and minor-bumps from there, then overwrites `Chart.yaml`, so the final published versions will be whatever ChartMuseum_current + 1.

## Bumps

| chart | main → this PR | live (ChartMuseum) | expected publish |
|---|---|---|---|
| datadog | 0.39.0 → 0.40.0 | 0.40.0 | 0.41.0 |
| grafana | 0.12.0 → 0.13.0 | 0.12.0 | 0.13.0 |
| logdna | 0.3.0 → 0.4.0 | 0.3.0 | 0.4.0 |
| redis | 0.19.0 → 0.20.0 | 0.19.0 | 0.20.0 |
| tailscale-operator | 0.1.0 → 0.2.0 | 0.1.0 | 0.2.0 |

(For `datadog`, main was already behind live — same drift situation that #1697 addressed for web/job. The 0.39.0 → 0.40.0 bump matches live so the workflow's next minor-bump lands at 0.41.0.)

## On-merge behavior

For each of the five charts, the workflow will:
1. Detect the Chart.yaml diff in the chart directory → `must_package=true`.
2. Query ChartMuseum for the live version, minor-bump, overwrite Chart.yaml.
3. Auto-commit (with `[skip ci]`) and publish the new version. The published artifact bundles all files in the chart directory at the current ref — including the digest pins from #1695.

No other charts will republish (nothing else in their directories changed).

## Test plan

- [ ] After merge, verify the publish workflow run for this PR completes successfully.
- [ ] Confirm ChartMuseum shows the new versions (datadog 0.41.0, grafana 0.13.0, logdna 0.4.0, redis 0.20.0, tailscale-operator 0.2.0).
- [ ] Spot-check a `helm pull` of one of the new versions and confirm the pinned digests from #1695 are present in its values.yaml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
