### PR TITLE
feat: optional posixUser on persistent-disk EFS storage class

### DIFF
--- a/addons/persistent-disk/Chart.yaml
+++ b/addons/persistent-disk/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: persistent-disk
 description: A Helm chart for creating a persistent disk via a StorageClass, PV, and PVC, backed by Cloud Provider disks.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"

--- a/addons/persistent-disk/templates/storageclass.yaml
+++ b/addons/persistent-disk/templates/storageclass.yaml
@@ -22,4 +22,8 @@ parameters:
   reuseAccessPoint: {{ .Values.storageClass.reuseAccessPoint | quote }}
   fileSystemId: {{ .Values.storageClass.efs.fileSystemId | quote }}
   provisioningMode: {{ .Values.storageClass.efs.provisioningMode | quote }}
+  {{- with .Values.storageClass.efs.posixUser }}
+  uid: {{ .uid | quote }}
+  gid: {{ .gid | quote }}
+  {{- end }}
 {{- end }}

--- a/addons/persistent-disk/values.yaml
+++ b/addons/persistent-disk/values.yaml
@@ -12,6 +12,12 @@ storageClass:
     fileSystemId: ""
     provisioningMode: "efs-ap"
     provisioner: efs.csi.aws.com
+    # posixUser pins the POSIX identity (uid/gid) every dynamically provisioned
+    # access point enforces on file operations, e.g. {uid: "0", gid: "0"}.
+    # Unset keeps the driver default: a unique generated identity per access
+    # point. Note this is part of the access point, so changing it only affects
+    # newly provisioned volumes.
+    posixUser: {}
 
 persistentVolumeClaim:
   requestStorage: "5Gi"


### PR DESCRIPTION
## Description

Adds an optional `storageClass.efs.posixUser` value (`{uid, gid}`) that renders as the `uid`/`gid` parameters on the EFS StorageClass, pinning the POSIX identity every dynamically provisioned access point enforces. Unset keeps today's behavior (driver generates a unique identity per access point).

The sandbox volumes work needs this: sandbox workloads run as root under gVisor, which sets file ownership on create, and an access point with a generated identity rejects that with EPERM - so every volume write fails. Pinning the sandbox disk's access points to `0:0` (done monolith-side in a porter-dev/code follow-up) makes the enforced identity match the workload. Verified on a dev cluster: generated-identity AP fails root writes under gVisor, `uid: "0", gid: "0"` AP works.