### PR TITLE
fix: render posixUser uid/gid in persistent-disk efs StorageClass

### DIFF
--- a/addons/persistent-disk/Chart.yaml
+++ b/addons/persistent-disk/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: persistent-disk
 description: A Helm chart for creating a persistent disk via a StorageClass, PV, and PVC, backed by Cloud Provider disks.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"

--- a/addons/persistent-disk/templates/storageclass.yaml
+++ b/addons/persistent-disk/templates/storageclass.yaml
@@ -22,4 +22,12 @@ parameters:
   reuseAccessPoint: {{ .Values.storageClass.reuseAccessPoint | quote }}
   fileSystemId: {{ .Values.storageClass.efs.fileSystemId | quote }}
   provisioningMode: {{ .Values.storageClass.efs.provisioningMode | quote }}
+  {{- with .Values.storageClass.efs.posixUser }}
+  {{- if hasKey . "uid" }}
+  uid: {{ .uid | quote }}
+  {{- end }}
+  {{- if hasKey . "gid" }}
+  gid: {{ .gid | quote }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/addons/persistent-disk/values.yaml
+++ b/addons/persistent-disk/values.yaml
@@ -12,6 +12,11 @@ storageClass:
     fileSystemId: ""
     provisioningMode: "efs-ap"
     provisioner: efs.csi.aws.com
+    # Pins the enforced POSIX identity on every provisioned access point. Left
+    # unset, the driver generates a per-access-point identity that rejects root
+    # writes with EPERM, so set uid/gid to "0" for workloads that write as root
+    # (e.g. gVisor sandboxes).
+    posixUser: {}
 
 persistentVolumeClaim:
   requestStorage: "5Gi"


### PR DESCRIPTION
## Description

The monolith sandbox-disk provider (porter-dev/code#6085) passes `storageClass.efs.posixUser: {uid: "0", gid: "0"}` to pin every provisioned EFS access point to a root POSIX identity, but this chart's StorageClass template never read `posixUser`. The value was silently dropped, so access points fell back to the efs-csi driver's default per-AP generated identity (uid 50001).

That breaks writes: EFS only honors writes from a uid-0 client, so with the default identity every write from a gVisor sandbox (which runs as root) fails with EPERM - reads work, writes don't. Rendering `uid`/`gid` into the efs-ap parameters makes the access point enforce root and lets writes through.

The block is gated on `posixUser` being set, so existing persistent-disk installs render an unchanged StorageClass. One rollout note: StorageClass parameters are immutable, so any cluster with an already-provisioned sandbox-disk StorageClass needs it recreated (and fresh volumes, since `reuseAccessPoint` keeps existing access points) to pick this up (this currently doesn't matter in practice)