### PR TITLE
feat: static access point mode + deterministic subpaths for persistent-disk

### DIFF
--- a/addons/persistent-disk/Chart.yaml
+++ b/addons/persistent-disk/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: persistent-disk
 description: A Helm chart for creating a persistent disk via a StorageClass, PV, and PVC, backed by Cloud Provider disks.
 type: application
-version: 0.2.0
+version: 0.4.0
 appVersion: "0.1.0"

--- a/addons/persistent-disk/templates/persistentvolume.yaml
+++ b/addons/persistent-disk/templates/persistentvolume.yaml
@@ -1,0 +1,28 @@
+{{- /* In static access point mode the PVC binds to this pre-created PV, whose
+       CSI handle points at an existing EFS access point. Reclaim policy is
+       Retain so deleting the addon never deletes the shared access point. */ -}}
+{{- if and .Values.storageClass.efs.enabled .Values.storageClass.efs.accessPointId }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}
+  labels:
+    porter.run/addon-name: {{ .Release.Name }}
+    porter.run/addon-type: persistent-disk
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  capacity:
+    storage: {{ .Values.persistentVolumeClaim.requestStorage }}
+  accessModes:
+    {{- toYaml .Values.persistentVolumeClaim.accessModes | nindent 4 }}
+  storageClassName: ""
+  persistentVolumeReclaimPolicy: Retain
+  claimRef:
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+  csi:
+    driver: {{ .Values.storageClass.efs.provisioner }}
+    volumeHandle: {{ .Values.storageClass.efs.fileSystemId }}::{{ .Values.storageClass.efs.accessPointId }}
+{{- end }}

--- a/addons/persistent-disk/templates/persistentvolumeclaim.yaml
+++ b/addons/persistent-disk/templates/persistentvolumeclaim.yaml
@@ -20,5 +20,10 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistentVolumeClaim.requestStorage }}
+{{- if .Values.storageClass.efs.accessPointId }}
+  storageClassName: ""
+  volumeName: {{ .Release.Name }}-{{ .Release.Namespace }}
+{{- else }}
   storageClassName: {{ .Release.Name }}
+{{- end }}
 {{- end }}

--- a/addons/persistent-disk/templates/storageclass.yaml
+++ b/addons/persistent-disk/templates/storageclass.yaml
@@ -1,3 +1,6 @@
+{{- /* A static access point binds the PVC to an existing access point via a
+       static PV, so the dynamic StorageClass is not needed in that mode. */ -}}
+{{- if not .Values.storageClass.efs.accessPointId }}
 {{- $scName := .Values.storageClass.name | default (printf "pd-sc-%s" .Release.Name) -}}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -22,6 +25,15 @@ parameters:
   reuseAccessPoint: {{ .Values.storageClass.reuseAccessPoint | quote }}
   fileSystemId: {{ .Values.storageClass.efs.fileSystemId | quote }}
   provisioningMode: {{ .Values.storageClass.efs.provisioningMode | quote }}
+  {{- with .Values.storageClass.efs.basePath }}
+  basePath: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.storageClass.efs.subPathPattern }}
+  subPathPattern: {{ . | quote }}
+  {{- end }}
+  {{- if hasKey .Values.storageClass.efs "ensureUniqueDirectory" }}
+  ensureUniqueDirectory: {{ .Values.storageClass.efs.ensureUniqueDirectory | quote }}
+  {{- end }}
   {{- with .Values.storageClass.efs.posixUser }}
   {{- if hasKey . "uid" }}
   uid: {{ .uid | quote }}
@@ -30,4 +42,5 @@ parameters:
   gid: {{ .gid | quote }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/addons/persistent-disk/values.yaml
+++ b/addons/persistent-disk/values.yaml
@@ -17,6 +17,14 @@ storageClass:
     # writes with EPERM, so set uid/gid to "0" for workloads that write as root
     # (e.g. gVisor sandboxes).
     posixUser: {}
+    # basePath is the directory under the filesystem root that access points are
+    # provisioned beneath. subPathPattern templates each access point's root
+    # directory from the claim (.PVC.name, .PVC.namespace, .PV.name). Left unset,
+    # the driver uses its defaults. ensureUniqueDirectory, when set to "false",
+    # keeps the path exactly as subPathPattern renders it with no appended uid -
+    # only safe when subPathPattern already yields a unique path per claim.
+    basePath: ""
+    subPathPattern: ""
 
 persistentVolumeClaim:
   requestStorage: "5Gi"


### PR DESCRIPTION
## Description

The persistent-disk addon only ever dynamically provisions a fresh, isolated EFS access point per claim, so there's no way to point an app at an existing access point or to control where claims land on the filesystem.

This adds `basePath`/`subPathPattern`/`ensureUniqueDirectory` passthrough on the storage class, plus a static mode: when `storageClass.efs.accessPointId` is set, the chart renders a Retain PV bound to that access point and a matching PVC instead of the dynamic storage class.

It backs the sandbox shared-volumes disk on the backend side. The deterministic subpaths key each volume's directory by its immutable id so one viewer access point can expose every sandbox volume, and Retain means deleting the addon never deletes the shared access point.