### PR TITLE
ignore default tolerations for newrelic ksm deployment

### DIFF
--- a/addons/nri-bundle/Chart.yaml
+++ b/addons/nri-bundle/Chart.yaml
@@ -16,7 +16,7 @@ sources:
   - https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie
   - https://github.com/newrelic/newrelic-infra-operator/tree/master/charts/newrelic-infra-operator
   - https://github.com/newrelic/k8s-agents-operator/tree/master/charts/k8s-agents-operator
-version: 0.13.0
+version: 0.13.1
 dependencies:
   - name: newrelic-infrastructure
     repository: https://newrelic.github.io/nri-kubernetes

--- a/addons/nri-bundle/values.yaml
+++ b/addons/nri-bundle/values.yaml
@@ -1,6 +1,8 @@
 newrelic-infrastructure:
   # newrelic-infrastructure.enabled -- Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
   enabled: true
+  ksm:
+    tolerations: []
 
 nri-prometheus:
   # nri-prometheus.enabled -- Install the [`nri-prometheus` chart](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus)
@@ -44,7 +46,6 @@ newrelic-prometheus-agent:
 newrelic-k8s-metrics-adapter:
   # newrelic-k8s-metrics-adapter.enabled -- Install the [`newrelic-k8s-metrics-adapter.` chart](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) (Beta)
   enabled: false
-
 
 # -- change the behaviour globally to all the supported helm charts.
 # See [user's guide of the common library](https://github.com/newrelic/helm-charts/blob/master/library/common-library/README.md) for further information.
@@ -130,8 +131,6 @@ global:
   # -- (bool) Sets the debug logs to this integration or all integrations if it is set globally
   # @default -- false
   verboseLog:
-
-
 # To add values to the subcharts. Follow Helm's guide: https://helm.sh/docs/chart_template_guide/subcharts_and_globals
 
 # If you wish to monitor services running on Kubernetes you can provide integrations


### PR DESCRIPTION
The `newrelic-infrastructure` subchart ships blanket `Exists`/`NoSchedule`+`NoExecute` tolerations on its kube-state-metrics (ksm) deployment, which lets the pod ignore cordons and taints and blocks node drains during cluster upgrades and pool deletes. 

This PR bakes a safe default into the porter `nri-bundle` chart so the ksm pod no longer tolerates everything.

Slack ref: 
https://getporter.slack.com/archives/C0AE617JKC2/p1782313372692489?thread_ts=1782142153.824689&cid=C0AE617JKC2
