### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/addons/kube-image-keeper/values.yaml
+++ b/addons/kube-image-keeper/values.yaml
@@ -232,7 +232,7 @@ registry:
     deleteUntagged: false
     image:
       # -- Cronjob image repository
-      repository: bitnami/kubectl
+      repository: soldevelo/kubectl
       # -- Cronjob image pull policy
       pullPolicy: IfNotPresent
       # -- Cronjob image tag. Default 'latest'


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/kubectl:latest` → [`soldevelo/kubectl:latest`](https://hub.docker.com/r/soldevelo/kubectl)